### PR TITLE
Add JWT service with token generation and validation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,76 @@
+# PayFlow
+
+Payment processing backend. University assignment (due mid-May) + portfolio piece targeting distributed systems roles.
+Every pattern here solves a real failure mode. The code must be defensible in a senior system design interview.
+
+## Environment
+| | |
+|---|---|
+| Java | 25 |
+| Spring Boot | 4.0.x |
+| Build | Maven, Jar |
+| Kafka | 3.9.0 — KRaft mode, no ZooKeeper |
+| Database | PostgreSQL 18 alpine |
+| Cache | Redis 8 alpine |
+| Schema | Flyway migrations only |
+| Tests | Testcontainers — real infra, never H2 or embedded Kafka |
+
+## Package Structure
+```
+com.payflow
+├── application/
+│   ├── command/          ← POJOs, zero Spring imports
+│   ├── commandhandler/   ← write side, @Transactional(SERIALIZABLE)
+│   └── query/            ← read side, @Transactional(readOnly=true)
+├── domain/
+│   ├── model/            ← aggregates, value objects — NO framework deps, ever
+│   ├── event/            ← domain event POJOs
+│   └── repository/       ← interfaces only
+├── infrastructure/
+│   ├── persistence/      ← JPA entities, Spring Data impls
+│   ├── kafka/            ← OutboxRelay, consumers, KafkaConfig
+│   ├── security/         ← JwtFilter, SecurityConfig
+│   └── projection/       ← read model tables + updaters
+└── api/
+    ├── controller/       ← thin, delegates only — no business logic
+    ├── dto/              ← request/response DTOs
+    └── exception/        ← @ControllerAdvice
+```
+
+## Transaction Rules (quick ref)
+| Context | Config |
+|---|---|
+| Command handlers | `@Transactional(isolation = Isolation.SERIALIZABLE)` |
+| Query handlers | `@Transactional(readOnly = true)` |
+| Outbox relay | `@Transactional(propagation = Propagation.REQUIRES_NEW)` |
+| Consumer idempotency | `TransactionTemplate` wrapping check + process + ack |
+| Controllers | never `@Transactional` |
+
+Self-invocation bypasses the AOP proxy — `@Transactional` silently does nothing when called via `this`.
+
+## Data Rules (quick ref)
+- Money: `BIGINT` cents — never `DECIMAL`, never `FLOAT`
+- PKs: `UUID` generated at domain layer, not by the DB
+- Balance: always derived (`SUM(ledger_entries)`), never a mutable column
+- Schema: Flyway only — `ddl-auto: validate` everywhere
+
+## Hard Rules (never do these)
+- `@Transactional` on a controller
+- Spring/JPA imports in `domain/`
+- Direct `kafkaTemplate.send()` inside a command handler — use outbox
+- H2 or embedded Kafka in tests
+- `DECIMAL`/`FLOAT` for money
+- `ddl-auto: create` or `update`
+- Business logic in a controller or DTO
+- Aggregate state mutated from outside the aggregate root
+- Hardcoded constants duplicated across classes
+- Abstractions for requirements that don't exist yet
+
+## Reference Docs
+Read these when working on anything touching the relevant area:
+
+| Topic | File |
+|---|---|
+| Outbox, CQRS, Saga, Idempotent Consumer, Event Sourcing, Double-Entry | `.claude/docs/architecture-patterns.md` |
+| Repository, Factory, Strategy, Observer | `.claude/docs/design-patterns.md` |
+| SOLID, YAGNI, DRY, DDD, Fail Fast | `.claude/docs/principles.md` |

--- a/.claude/commands/explain.md
+++ b/.claude/commands/explain.md
@@ -1,0 +1,16 @@
+# /explain
+
+Explain how a pattern, principle, or decision is implemented in PayFlow specifically.
+Read the relevant doc from `.claude/docs/` before answering.
+
+Focus on:
+- What it does in **this codebase** — not generic theory
+- Where exactly it lives in the package structure
+- The concrete failure mode it prevents (be specific — "double debit", "lost event", "stale balance")
+- How it interacts with other patterns in PayFlow
+- A code example if it makes the explanation materially clearer
+
+Be direct and concrete. No padding.
+
+## Topic
+$ARGUMENTS

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,76 @@
+# /pr
+
+Create a GitHub pull request from the current branch using the `gh` CLI.
+Reads the diff, generates the description, picks labels, and runs `gh pr create`.
+
+## Steps
+
+1. Run `git diff main --stat` to see what files changed
+2. Run `git diff main` to read the actual diff
+3. Run `git log main..HEAD --oneline` to see commits on this branch
+4. Infer the linked issue number from the branch name (e.g. `feature/12-outbox-relay` → `#12`)
+5. Generate title, body, and labels (see rules below)
+6. Run `gh pr create` with all of it — do not ask for confirmation, just run it
+
+## Title Rules
+- Imperative, specific, ≤72 chars
+- ✅ `Add idempotent consumer for PaymentInitiated events`
+- ❌ `Fix some payment stuff` / `WIP` / `Updates`
+
+## Body Format
+```
+## What
+One sentence. What does this PR do at the code level?
+
+## Linked Issue
+Closes #N
+
+## Why
+The failure mode this prevents or the requirement it fulfils.
+Reference the pattern by name if relevant (Outbox, Idempotent Consumer, CQRS, etc.).
+
+## Changes
+- bullet list of meaningful changes grouped by layer
+- skip mechanical things: imports, formatting, renames
+
+## Testing
+- what test classes were added
+- which failure cases are covered (idempotency, concurrent writes, outbox atomicity, etc.)
+- confirm Testcontainers used for integration tests, not H2
+
+## Notes
+Deliberate trade-offs, known limitations, follow-up issues — omit section if none.
+```
+
+## Label Rules
+
+Pick from PayFlow's label taxonomy only. Apply all that match.
+
+**Type (pick one):**
+- `type: feature` — new behaviour
+- `type: bug` — fixing broken behaviour
+- `type: chore` — tooling, config, scaffolding, no business logic
+- `type: research` — investigation, spike, reading
+
+**Layer (pick all that apply):**
+- `layer: domain` — anything in `domain/`
+- `layer: persistence` — JPA, Flyway migrations, `infrastructure/persistence/`
+- `layer: kafka` — Kafka consumers, producers, OutboxRelay, `infrastructure/kafka/`
+- `layer: api` — controllers, DTOs, `api/`
+- `layer: security` — JWT, filters, `infrastructure/security/`
+- `layer: infra` — Docker, CI/CD, config, `infrastructure/` general
+
+**Always add:**
+- `status: in-progress` is for issues — PRs don't get status labels
+
+## Command to Run
+```bash
+gh pr create \
+  --title "<generated title>" \
+  --body "<generated body>" \
+  --label "<label1>" \
+  --label "<label2>" \
+  --label "<label3>"
+```
+
+If `gh` is not authenticated or the remote is not set, report the error clearly and print the generated title and body so it can be copy-pasted manually.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,62 @@
+# /review
+
+Review the provided code or diff against PayFlow's standards.
+Read `.claude/docs/architecture-patterns.md`, `.claude/docs/design-patterns.md`, and `.claude/docs/principles.md` before starting.
+
+## Checklist
+
+**Architecture**
+- [ ] State change and outbox entry written in the same transaction?
+- [ ] CQRS boundary respected — no business logic on read side, no SERIALIZABLE on reads?
+- [ ] Consumer checks `processed_events` before processing, inside the same transaction?
+- [ ] Domain layer (`domain/`) has zero Spring/JPA/Kafka imports?
+- [ ] Aggregate state only mutated through the aggregate root?
+
+**Transactions**
+- [ ] Command handlers: `Isolation.SERIALIZABLE`?
+- [ ] Query handlers: `readOnly = true`?
+- [ ] Outbox relay: `Propagation.REQUIRES_NEW`?
+- [ ] `@Transactional` on a controller? (never allowed)
+- [ ] Any risk of self-invocation bypassing the AOP proxy?
+
+**Kafka**
+- [ ] `enable-auto-commit: false`?
+- [ ] `ack.acknowledge()` called only after transaction commits?
+- [ ] Producer going through outbox — not direct `kafkaTemplate.send()` in a handler?
+- [ ] Dead letter topic configured?
+
+**Data**
+- [ ] Money as `BIGINT` cents — not `DECIMAL`, not `FLOAT`?
+- [ ] UUID generated at domain layer, not DB?
+- [ ] Balance derived from ledger, not stored as mutable column?
+- [ ] `@Version` on aggregates with concurrent write risk?
+
+**Design**
+- [ ] Any class doing more than one job? (SRP)
+- [ ] New event types added without modifying existing classes? (OCP)
+- [ ] Domain interfaces kept focused — no fat interfaces? (ISP)
+- [ ] High-level modules importing only domain interfaces, not infra impls? (DIP)
+- [ ] Any abstractions built for requirements that don't exist? (YAGNI)
+- [ ] Any duplicated constants or knowledge? (DRY)
+
+**Tests**
+- [ ] Integration tests use Testcontainers — real Postgres 18, real Kafka 3.9.0?
+- [ ] No H2, no embedded Kafka?
+- [ ] Naming follows `should_[expected]_when_[condition]`?
+- [ ] Idempotency case covered?
+- [ ] Concurrent write case covered?
+
+## Output Format
+
+For each issue:
+1. **Severity**: `BLOCKER` | `WARNING` | `SUGGESTION`
+2. **Location**: class + method/line
+3. **Problem**: what's wrong and which failure mode it introduces
+4. **Fix**: corrected code snippet
+
+Then a summary:
+- Overall assessment (1–2 sentences)
+- BLOCKER / WARNING / SUGGESTION counts
+- Merge-ready: Yes / No / Yes with caveats
+
+$ARGUMENTS

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,44 @@
+# /test
+
+Write tests for the provided class or feature.
+Read `.claude/docs/architecture-patterns.md` before writing integration tests.
+
+## Test Types
+
+**Domain unit tests** — no Spring context, no Testcontainers
+- Pure Java, JUnit 5 only
+- Test aggregate behaviour: given events → assert state, emitted events, thrown exceptions
+- Fast — no infra required
+
+**Integration tests** — `@SpringBootTest` + `@Testcontainers`
+- Real PostgreSQL 18 alpine via Testcontainers
+- Real Apache Kafka 3.9.0 via Testcontainers
+- Test the full flow: HTTP request → command handler → DB → outbox relay → Kafka → consumer → projection
+- Assert on actual DB state — not on mocks or captures
+- Never H2, never embedded Kafka
+
+## What NOT to Mock
+- `JpaRepository` implementations — use real DB via Testcontainers
+- `KafkaTemplate` — use real Kafka via Testcontainers
+- Domain collaborators that have infrastructure concerns — test the real thing
+
+## Naming Convention
+```
+should_[expected outcome]_when_[condition]
+
+should_create_payment_when_command_is_valid()
+should_reject_payment_when_insufficient_funds()
+should_be_idempotent_when_same_event_id_received_twice()
+should_throw_when_source_and_target_accounts_are_identical()
+should_rollback_outbox_entry_when_event_store_write_fails()
+```
+
+## Required Cases for Every Financial Operation
+1. Happy path — valid input, expected state after
+2. Invalid input — bad amounts, missing fields, wrong state
+3. Idempotency — same event delivered twice → second is a no-op, state unchanged
+4. Concurrent modification — two operations on same aggregate simultaneously → optimistic lock exception, handled gracefully
+5. Outbox atomicity — consumer crashes after event store write → outbox entry still present and unpublished
+
+## Request
+$ARGUMENTS

--- a/.claude/docs/architecture-patterns.md
+++ b/.claude/docs/architecture-patterns.md
@@ -1,0 +1,244 @@
+# PayFlow — Architecture Patterns
+
+## Outbox Pattern
+
+**Problem it solves:** Without outbox, a crash between `session.commit()` and `kafkaTemplate.send()` permanently loses the event. Money moved in the DB, but nothing downstream ever knows.
+
+**How it works:** Write the domain event to an `outbox_events` table inside the same DB transaction as the state change. A `@Scheduled` relay reads unprocessed outbox rows and publishes them to Kafka in a separate transaction (`REQUIRES_NEW`). The relay marks rows as processed only after Kafka confirms receipt.
+
+**✅ Good**
+```java
+@Transactional(isolation = Isolation.SERIALIZABLE)
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = Payment.initiate(cmd);
+    eventStore.save(payment.domainEvents());
+
+    // Written atomically with the state change — one transaction, one commit
+    outboxRepository.save(OutboxEvent.from(new PaymentInitiated(payment.id())));
+}
+
+// Relay runs separately — REQUIRES_NEW so each batch is its own tx
+@Scheduled(fixedDelay = 500)
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public void relay() {
+    List<OutboxEvent> batch = outboxRepository.findUnprocessed(100);
+    batch.forEach(event -> kafkaTemplate.send("payments", event.payload()));
+    outboxRepository.markProcessed(batch);
+}
+```
+
+**❌ Bad**
+```java
+@Transactional
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = Payment.initiate(cmd);
+    eventStore.save(payment.domainEvents());
+    // DB transaction commits here
+
+    // Crash here = event lost permanently. No retry, no recovery.
+    kafkaTemplate.send("payments", new PaymentInitiated(payment.id()));
+}
+```
+
+---
+
+## CQRS (Command Query Responsibility Segregation)
+
+**Problem it solves:** Write operations need SERIALIZABLE isolation and rich domain logic for correctness. Read operations need speed. Putting them in the same class/model means applying the strictest constraints everywhere — unnecessary lock contention and complexity on the read path.
+
+**How it works:** Strict separation between write side (`commandhandler/`) and read side (`query/`). They use different transaction configs, different models, and different tables. The read model (projections) is updated by consuming domain events from Kafka — eventually consistent, but fast.
+
+**✅ Good**
+```java
+// Write side — correctness, SERIALIZABLE, domain model
+@Service
+public class PaymentCommandHandler {
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public void handle(InitiatePaymentCommand cmd) {
+        Payment payment = Payment.initiate(cmd);
+        eventStore.save(payment.domainEvents());
+        outboxRepository.save(OutboxEvent.from(new PaymentInitiated(payment.id())));
+    }
+}
+
+// Read side — speed, readOnly, denormalized projection table
+@Service
+public class PaymentQueryHandler {
+    @Transactional(readOnly = true)
+    public TransactionHistoryDTO getHistory(UUID accountId) {
+        return transactionProjectionRepository.findByAccountId(accountId);
+    }
+}
+```
+
+**❌ Bad**
+```java
+// One class handling both — SERIALIZABLE applied to reads for no reason,
+// domain model exposed to the read path, no separation of concerns
+@Service
+public class PaymentService {
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public PaymentEntity initiatePayment(InitiatePaymentCommand cmd) { ... }
+
+    @Transactional(isolation = Isolation.SERIALIZABLE) // pointless on a read
+    public PaymentEntity getPayment(UUID id) {
+        return paymentRepository.findById(id).orElseThrow();
+    }
+}
+```
+
+---
+
+## Idempotent Consumer
+
+**Problem it solves:** Kafka guarantees at-least-once delivery. After a consumer crash, rebalance, or timeout, the broker redelivers the last unacknowledged message. Without idempotency: double debit, double credit, double refund.
+
+**How it works:** Before processing an event, check `processed_events` for the event ID. The check, the domain logic, and the insert into `processed_events` all happen inside one transaction. Kafka ack is sent only after the transaction commits.
+
+**✅ Good**
+```java
+@KafkaListener(topics = "payments", groupId = "payflow-consumers")
+public void consume(ConsumerRecord<String, PaymentInitiated> record, Acknowledgment ack) {
+    transactionTemplate.execute(status -> {
+        String eventId = record.value().eventId();
+
+        // Check, process, and record — all in one transaction
+        if (processedEventRepository.existsByEventId(eventId)) {
+            return null; // already handled — skip silently
+        }
+
+        applyPaymentInitiated(record.value());
+        processedEventRepository.save(new ProcessedEvent(eventId));
+        return null;
+    });
+
+    ack.acknowledge(); // only after commit — safe to ack now
+}
+```
+
+**❌ Bad**
+```java
+// enable-auto-commit: true in config (never acceptable in PayFlow)
+@KafkaListener(topics = "payments")
+public void consume(PaymentInitiated event) {
+    // No idempotency check — redelivery = double processing
+    applyPaymentInitiated(event);
+    // Kafka auto-acks on return — acks before any persistence, crash = reprocess
+}
+```
+
+---
+
+## Saga (Choreography-Based)
+
+**Problem it solves:** A cross-account transfer touches multiple aggregates. A traditional 2PC distributed transaction is fragile under partial failure and holds locks across services. Saga coordinates via compensating events instead of global rollback.
+
+**How it works:** Each step in the flow publishes a domain event. The next service reacts to that event and publishes its own. On failure, a compensating event triggers the rollback of previous steps. No central orchestrator — services are decoupled.
+
+**✅ Good**
+```
+PaymentInitiated →
+    [Account Service]   FundsReserved | InsufficientFundsDetected →
+    [Ledger Service]    LedgerEntriesPosted | LedgerPostingFailed →
+    [Account Service]   FundsReleased  ← compensating tx if any step failed
+    [Payment Service]   PaymentCompleted | PaymentFailed
+```
+Each step is independently retryable and idempotent. Failure triggers a compensating event chain — not a global lock release.
+
+**❌ Bad**
+```java
+// Synchronous orchestration — one failure breaks everything, locks held across calls
+public void transfer(TransferCommand cmd) {
+    accountService.debit(cmd.sourceId(), cmd.amount());   // HTTP call
+    ledgerService.post(cmd);                               // HTTP call — if this throws:
+    accountService.credit(cmd.targetId(), cmd.amount());  // never reached, money gone
+}
+```
+
+---
+
+## Double-Entry Ledger
+
+**Problem it solves:** A mutable `balance` column can desync from reality with no trace of how it happened. There's no audit trail, no way to reconstruct history, and no way to detect corruption.
+
+**How it works:** Every money movement creates two rows in `ledger_entries` — a debit on one account and a credit on another. Balance is never stored; it's always derived by summing ledger entries for an account. Every cent is traceable to a payment.
+
+**✅ Good**
+```sql
+CREATE TABLE ledger_entries (
+    id           UUID PRIMARY KEY,
+    account_id   UUID NOT NULL,
+    amount_cents BIGINT NOT NULL,         -- positive = credit, negative = debit
+    entry_type   VARCHAR(10) NOT NULL,    -- 'DEBIT' | 'CREDIT'
+    payment_id   UUID NOT NULL REFERENCES payments(id),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Balance is always derived — never stale, never wrong without an explanation
+SELECT SUM(amount_cents) FROM ledger_entries WHERE account_id = $1;
+```
+
+```java
+// Both entries written in the same transaction as the payment
+public void postLedgerEntries(Payment payment) {
+    ledgerRepository.save(LedgerEntry.debit(payment.sourceAccountId(), payment.amountCents(), payment.id()));
+    ledgerRepository.save(LedgerEntry.credit(payment.targetAccountId(), payment.amountCents(), payment.id()));
+}
+```
+
+**❌ Bad**
+```sql
+-- Direct mutation — no audit trail, can go negative silently, can desync
+UPDATE accounts SET balance_cents = balance_cents - 5000 WHERE id = $1;
+UPDATE accounts SET balance_cents = balance_cents + 5000 WHERE id = $2;
+-- If second UPDATE crashes: 5000 cents vanished with no record
+```
+
+---
+
+## Event Sourcing
+
+**Problem it solves:** Point-in-time state tables lose history. If a projection has a bug that corrupts read data, there's no way to rebuild it. Financial systems require a complete, immutable audit trail.
+
+**How it works:** `event_store` is append-only and is the single source of truth. Aggregates are reconstructed by replaying all their events. Projection tables are derived views — they can always be dropped and rebuilt by replaying the event store.
+
+**✅ Good**
+```java
+// Aggregate loaded by replaying its full event history
+public Payment load(UUID paymentId) {
+    List<DomainEvent> events = eventStore.findByAggregateId(paymentId);
+    if (events.isEmpty()) throw new PaymentNotFoundException(paymentId);
+    return Payment.reconstitute(events);
+}
+
+// Aggregate accumulates events, never mutates external state directly
+public class Payment {
+    public static Payment reconstitute(List<DomainEvent> events) {
+        Payment payment = new Payment();
+        events.forEach(payment::apply);
+        return payment;
+    }
+
+    private void apply(PaymentInitiated event) {
+        this.id = event.paymentId();
+        this.status = PaymentStatus.PENDING;
+        this.amountCents = event.amountCents();
+    }
+}
+```
+
+**❌ Bad**
+```java
+// Snapshot table only — history is gone, projections can't be rebuilt
+public Payment load(UUID paymentId) {
+    return paymentRepository.findById(paymentId)
+        .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+}
+
+// State is overwritten, not appended
+public void complete(UUID paymentId) {
+    Payment payment = load(paymentId);
+    payment.setStatus("COMPLETED");     // history of how it got here: gone
+    paymentRepository.save(payment);
+}
+```

--- a/.claude/docs/design-patterns.md
+++ b/.claude/docs/design-patterns.md
@@ -1,0 +1,234 @@
+# PayFlow — Design Patterns
+
+## Repository Pattern
+
+**Problem it solves:** Domain logic shouldn't know or care how data is stored. Direct JPA usage in aggregates or command handlers couples business logic to infrastructure, making the domain impossible to test without a database.
+
+**How it works:** `domain/repository/` defines interfaces with domain language. `infrastructure/persistence/` implements them with Spring Data JPA. The domain layer imports only the interface — never the implementation.
+
+**✅ Good**
+```java
+// domain/repository/EventStoreRepository.java — zero Spring/JPA imports
+public interface EventStoreRepository {
+    void save(List<DomainEvent> events);
+    List<DomainEvent> findByAggregateId(UUID aggregateId);
+    List<DomainEvent> findByAggregateIdFromVersion(UUID aggregateId, long fromVersion);
+}
+
+// infrastructure/persistence/JpaEventStoreRepository.java
+@Repository
+public class JpaEventStoreRepository implements EventStoreRepository {
+    private final EventStoreJpaRepository jpa; // Spring Data repo
+
+    @Override
+    public void save(List<DomainEvent> events) {
+        jpa.saveAll(events.stream().map(EventStoreEntity::from).toList());
+    }
+
+    @Override
+    public List<DomainEvent> findByAggregateId(UUID aggregateId) {
+        return jpa.findByAggregateIdOrderByVersion(aggregateId)
+                  .stream().map(EventStoreEntity::toDomain).toList();
+    }
+}
+
+// PaymentCommandHandler depends on the interface — not the JPA impl
+@Service
+public class PaymentCommandHandler {
+    private final EventStoreRepository eventStore; // domain interface
+
+    public PaymentCommandHandler(EventStoreRepository eventStore) {
+        this.eventStore = eventStore;
+    }
+}
+```
+
+**❌ Bad**
+```java
+// Domain aggregate directly using Spring Data — Spring in the domain layer
+@Entity
+public class Payment {
+    @Autowired
+    private PaymentJpaRepository repo; // Spring dep inside domain — kills testability
+
+    public void complete() {
+        this.status = "COMPLETED";
+        repo.save(this); // aggregate persisting itself via infrastructure
+    }
+}
+```
+
+---
+
+## Factory Pattern
+
+**Problem it solves:** Complex object construction scattered across handlers creates duplication and makes invariant enforcement unreliable. If constructing a `Payment` requires 6 fields and a validation step, that logic should live in one place.
+
+**How it works:** Named static factory methods on aggregates and domain events handle construction. They enforce invariants at creation time and make intent explicit. Handlers call `Payment.initiate(cmd)` — not `new Payment()` with a dozen setters.
+
+**✅ Good**
+```java
+// Aggregate — named factory method enforces invariants at creation
+public class Payment {
+    private Payment() {} // no public constructor
+
+    public static Payment initiate(UUID sourceAccountId, UUID targetAccountId, long amountCents) {
+        if (amountCents <= 0) throw new InvalidPaymentAmountException(amountCents);
+        if (sourceAccountId.equals(targetAccountId)) throw new SelfTransferException(sourceAccountId);
+
+        Payment payment = new Payment();
+        payment.id = UUID.randomUUID(); // generated here, not by DB
+        payment.sourceAccountId = sourceAccountId;
+        payment.targetAccountId = targetAccountId;
+        payment.amountCents = amountCents;
+        payment.status = PaymentStatus.PENDING;
+
+        payment.recordEvent(new PaymentInitiated(payment.id, sourceAccountId, targetAccountId, amountCents));
+        return payment;
+    }
+}
+
+// OutboxEvent — factory method from domain event keeps mapping in one place
+public class OutboxEvent {
+    public static OutboxEvent from(DomainEvent event) {
+        return new OutboxEvent(
+            UUID.randomUUID(),
+            event.aggregateId(),
+            event.getClass().getSimpleName(),
+            serialize(event),
+            Instant.now()
+        );
+    }
+}
+
+// Handler stays clean — construction logic not its concern
+@Transactional(isolation = Isolation.SERIALIZABLE)
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = Payment.initiate(cmd.sourceAccountId(), cmd.targetAccountId(), cmd.amountCents());
+    eventStore.save(payment.domainEvents());
+    outboxRepository.save(OutboxEvent.from(payment.domainEvents().getLast()));
+}
+```
+
+**❌ Bad**
+```java
+// Construction logic duplicated in every handler — invariants enforced nowhere
+@Transactional(isolation = Isolation.SERIALIZABLE)
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = new Payment();
+    payment.setId(UUID.randomUUID());
+    payment.setSourceAccountId(cmd.sourceAccountId());
+    payment.setTargetAccountId(cmd.targetAccountId());
+    payment.setAmountCents(cmd.amountCents());
+    payment.setStatus("PENDING");
+    payment.setCreatedAt(Instant.now());
+    // No validation — nothing stops amountCents = -500 from getting through
+    eventStore.save(payment);
+}
+```
+
+---
+
+## Strategy Pattern
+
+**Problem it solves:** When behaviour needs to be swappable at runtime or easily replaceable without touching the caller, hardcoding the algorithm couples the caller to the implementation. Strategy externalises the algorithm behind an interface.
+
+**How it works:** Define an interface for the algorithm. Inject whichever implementation is needed. The caller knows the interface, not the implementation. Swap implementations without modifying the handler.
+
+**✅ Good**
+```java
+// Interface — algorithm is interchangeable
+public interface IdempotencyKeyStrategy {
+    String generate(InitiatePaymentCommand cmd);
+}
+
+// One implementation
+@Component
+public class HmacIdempotencyKeyStrategy implements IdempotencyKeyStrategy {
+    @Override
+    public String generate(InitiatePaymentCommand cmd) {
+        return Hmac.sha256(cmd.sourceAccountId() + cmd.targetAccountId() + cmd.amountCents());
+    }
+}
+
+// Another — swap in tests or for different contexts without touching handler
+@Component
+public class UuidIdempotencyKeyStrategy implements IdempotencyKeyStrategy {
+    @Override
+    public String generate(InitiatePaymentCommand cmd) {
+        return UUID.randomUUID().toString();
+    }
+}
+
+// Handler doesn't know which strategy it's using
+@Service
+public class PaymentCommandHandler {
+    private final IdempotencyKeyStrategy idempotencyKeyStrategy;
+
+    public PaymentCommandHandler(IdempotencyKeyStrategy idempotencyKeyStrategy, ...) {
+        this.idempotencyKeyStrategy = idempotencyKeyStrategy;
+    }
+
+    public void handle(InitiatePaymentCommand cmd) {
+        String key = idempotencyKeyStrategy.generate(cmd);
+        // ... rest of handler
+    }
+}
+```
+
+**❌ Bad**
+```java
+// Algorithm hardcoded in handler — changing it means modifying the handler
+public void handle(InitiatePaymentCommand cmd) {
+    // Idempotency logic inline — not testable in isolation, not swappable
+    String key = Hmac.sha256(cmd.sourceAccountId() + cmd.targetAccountId() + cmd.amountCents());
+    if (processedKeyRepository.existsByKey(key)) return;
+    // ...
+}
+```
+
+---
+
+## Observer Pattern (via Kafka)
+
+**Problem it solves:** When a payment completes, multiple downstream concerns need to react — update projections, trigger notifications, update the ledger, run fraud checks. Coupling the payment handler to every downstream consumer makes it a god class and forces redeployment on every new consumer.
+
+**How it works:** The payment handler publishes a domain event (via outbox → Kafka). Each downstream concern is an independent `@KafkaListener` in its own consumer group. New consumers can be added without touching the publisher.
+
+**✅ Good**
+```java
+// Publisher knows nothing about who's listening
+@Transactional(isolation = Isolation.SERIALIZABLE)
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = Payment.initiate(cmd.sourceAccountId(), cmd.targetAccountId(), cmd.amountCents());
+    eventStore.save(payment.domainEvents());
+    outboxRepository.save(OutboxEvent.from(new PaymentInitiated(payment.id())));
+    // Done — doesn't call projectionService, notificationService, fraudService
+}
+
+// Each observer is independent — adding one doesn't touch any other class
+@KafkaListener(topics = "payment.events", groupId = "projection-updater")
+public void onPaymentInitiated(PaymentInitiated event, Acknowledgment ack) { ... }
+
+@KafkaListener(topics = "payment.events", groupId = "fraud-checker")
+public void onPaymentInitiated(PaymentInitiated event, Acknowledgment ack) { ... }
+
+@KafkaListener(topics = "payment.events", groupId = "notification-sender")
+public void onPaymentInitiated(PaymentInitiated event, Acknowledgment ack) { ... }
+```
+
+**❌ Bad**
+```java
+// Handler coupled to every downstream concern — grows forever
+@Transactional(isolation = Isolation.SERIALIZABLE)
+public void handle(InitiatePaymentCommand cmd) {
+    Payment payment = Payment.initiate(...);
+    eventStore.save(payment.domainEvents());
+
+    // Direct calls — every new consumer = modifying this class
+    projectionService.update(payment);
+    notificationService.send(payment);
+    fraudService.check(payment);
+    ledgerService.post(payment);
+}
+```

--- a/.claude/docs/principles.md
+++ b/.claude/docs/principles.md
@@ -1,0 +1,340 @@
+# PayFlow — Engineering Principles
+
+## SOLID
+
+### Single Responsibility
+Each class has one reason to change. When a class changes for multiple unrelated reasons, those concerns are entangled — a bug fix in one risks breaking the other.
+
+**✅ Good**
+```java
+// PaymentCommandHandler — one job: handle payment commands
+@Service
+public class PaymentCommandHandler {
+    public void handle(InitiatePaymentCommand cmd) { ... }
+    public void handle(CancelPaymentCommand cmd) { ... }
+}
+
+// OutboxRelay — one job: relay outbox entries to Kafka
+@Component
+public class OutboxRelay {
+    @Scheduled(fixedDelay = 500)
+    public void relay() { ... }
+}
+
+// LedgerService — one job: post ledger entries
+@Service
+public class LedgerService {
+    public void post(Payment payment) { ... }
+}
+```
+
+**❌ Bad**
+```java
+// PaymentService doing five different jobs — five reasons to change
+@Service
+public class PaymentService {
+    public void initiatePayment(InitiatePaymentCommand cmd) { ... }
+    public void sendConfirmationEmail(Payment payment) { ... }  // notification concern
+    public void updateLedger(Payment payment) { ... }           // ledger concern
+    public void publishToKafka(Payment payment) { ... }         // infrastructure concern
+    public void checkFraud(Payment payment) { ... }             // fraud concern
+}
+```
+
+---
+
+### Open/Closed
+Open for extension, closed for modification. Adding new behaviour means adding new classes — not editing existing ones.
+
+**✅ Good**
+```java
+// Adding RefundInitiated handling = new class, zero changes to existing consumers
+public interface DomainEventHandler<T extends DomainEvent> {
+    void handle(T event, Acknowledgment ack);
+}
+
+@Component
+public class PaymentInitiatedHandler implements DomainEventHandler<PaymentInitiated> {
+    @Override public void handle(PaymentInitiated event, Acknowledgment ack) { ... }
+}
+
+// New event type — new class, existing handler untouched
+@Component
+public class RefundInitiatedHandler implements DomainEventHandler<RefundInitiated> {
+    @Override public void handle(RefundInitiated event, Acknowledgment ack) { ... }
+}
+```
+
+**❌ Bad**
+```java
+// Every new event type = editing this method — grows without bound
+public void processEvent(DomainEvent event) {
+    switch (event.type()) {
+        case "PAYMENT_INITIATED" -> handlePaymentInitiated((PaymentInitiated) event);
+        case "PAYMENT_COMPLETED" -> handlePaymentCompleted((PaymentCompleted) event);
+        case "REFUND_INITIATED"  -> handleRefundInitiated((RefundInitiated) event); // ← edit here every time
+    }
+}
+```
+
+---
+
+### Liskov Substitution
+Subtypes must be substitutable for their base type without breaking correctness. If the interface contract says idempotency is guaranteed, every implementation must honour that — not just the convenient ones.
+
+**✅ Good**
+```java
+// Every DomainEventHandler implementation upholds the idempotency contract
+public class PaymentInitiatedHandler implements DomainEventHandler<PaymentInitiated> {
+    public void handle(PaymentInitiated event, Acknowledgment ack) {
+        if (processedEventRepository.existsByEventId(event.eventId())) return; // idempotent
+        // process...
+    }
+}
+
+public class RefundInitiatedHandler implements DomainEventHandler<RefundInitiated> {
+    public void handle(RefundInitiated event, Acknowledgment ack) {
+        if (processedEventRepository.existsByEventId(event.eventId())) return; // same guarantee
+        // process...
+    }
+}
+```
+
+**❌ Bad**
+```java
+// RefundInitiatedHandler skips idempotency — LSP violation, redelivery = double refund
+public class RefundInitiatedHandler implements DomainEventHandler<RefundInitiated> {
+    public void handle(RefundInitiated event, Acknowledgment ack) {
+        // "refunds are rare, we'll skip the check" — now the subtype breaks the caller's assumption
+        applyRefund(event);
+        ack.acknowledge();
+    }
+}
+```
+
+---
+
+### Interface Segregation
+Don't force implementors to depend on methods they don't need. Fat interfaces create unnecessary coupling and make mocking painful in tests.
+
+**✅ Good**
+```java
+// Focused interfaces — each has a clear, single purpose
+public interface EventStoreRepository {
+    void save(List<DomainEvent> events);
+    List<DomainEvent> findByAggregateId(UUID aggregateId);
+}
+
+public interface OutboxRepository {
+    void save(OutboxEvent event);
+    List<OutboxEvent> findUnprocessed(int limit);
+    void markProcessed(List<OutboxEvent> events);
+}
+```
+
+**❌ Bad**
+```java
+// God interface — implementations are forced to stub methods they don't use
+public interface PaymentRepository {
+    void save(Payment payment);
+    Payment findById(UUID id);
+    void sendConfirmationEmail(Payment payment);    // not a repository concern
+    void publishToKafka(DomainEvent event);         // not a repository concern
+    void updateProjection(Payment payment);         // not a repository concern
+}
+```
+
+---
+
+### Dependency Inversion
+High-level modules depend on abstractions, not implementations. `PaymentCommandHandler` (high-level) must not import anything from `infrastructure/` (low-level). It imports interfaces from `domain/repository/` only.
+
+**✅ Good**
+```java
+// commandhandler imports the domain interface — not the JPA implementation
+import com.payflow.domain.repository.EventStoreRepository;  // ✅ domain interface
+import com.payflow.domain.repository.OutboxRepository;      // ✅ domain interface
+
+@Service
+public class PaymentCommandHandler {
+    private final EventStoreRepository eventStore;
+    private final OutboxRepository outbox;
+
+    public PaymentCommandHandler(EventStoreRepository eventStore, OutboxRepository outbox) {
+        this.eventStore = eventStore;
+        this.outbox = outbox;
+    }
+}
+```
+
+**❌ Bad**
+```java
+// commandhandler reaching into infrastructure — high-level coupled to low-level
+import com.payflow.infrastructure.persistence.JpaEventStoreRepository;  // ❌ JPA impl
+import org.springframework.kafka.core.KafkaTemplate;                     // ❌ infra in app layer
+
+@Service
+public class PaymentCommandHandler {
+    private final JpaEventStoreRepository eventStore;   // tied to JPA impl
+    private final KafkaTemplate<String, Object> kafka;  // bypasses outbox pattern too
+}
+```
+
+---
+
+## YAGNI (You Aren't Gonna Need It)
+
+Build what PayFlow needs now. Abstractions exist to solve real problems in the current codebase — not to prepare for imagined future requirements.
+
+**✅ Good**
+```java
+// PayFlow has one payment processing flow — implement it directly
+@Service
+public class PaymentCommandHandler {
+    public void handle(InitiatePaymentCommand cmd) {
+        Payment payment = Payment.initiate(cmd.sourceAccountId(), cmd.targetAccountId(), cmd.amountCents());
+        eventStore.save(payment.domainEvents());
+        outboxRepository.save(OutboxEvent.from(payment.domainEvents().getLast()));
+    }
+}
+```
+
+**❌ Bad**
+```java
+// Plugin architecture for a use case that doesn't exist — complexity for zero current value
+public interface PaymentProcessorPlugin {
+    boolean supports(PaymentType type);
+    Payment process(InitiatePaymentCommand cmd);
+}
+
+@Component
+public class PaymentProcessorRegistry {
+    private final List<PaymentProcessorPlugin> plugins;
+
+    public Payment process(InitiatePaymentCommand cmd) {
+        return plugins.stream()
+            .filter(p -> p.supports(cmd.paymentType()))
+            .findFirst()
+            .orElseThrow()
+            .process(cmd);
+    }
+}
+// PayFlow has one payment type. This solves nothing today.
+```
+
+---
+
+## DRY (Don't Repeat Yourself)
+
+Every piece of knowledge has one authoritative location. Duplication means two places to update, two places to get wrong.
+
+DRY applies to **knowledge**, not code shape. Two methods that look alike but represent distinct concepts should stay separate — forced unification creates the wrong abstraction.
+
+**✅ Good**
+```java
+// Batch size configured once — one place to change
+@Value("${payflow.outbox.batch-size}")
+private int batchSize;
+
+// Kafka topic names are constants — one source of truth
+public final class KafkaTopics {
+    public static final String PAYMENT_EVENTS = "payment.events";
+    public static final String LEDGER_EVENTS  = "ledger.events";
+
+    private KafkaTopics() {}
+}
+```
+
+**❌ Bad**
+```java
+// Same constant in three places — change one, forget the others
+// OutboxRelay.java
+List<OutboxEvent> batch = outboxRepository.findUnprocessed(100);
+
+// OutboxRelayTest.java
+assertThat(relay.getBatchSize()).isEqualTo(100);
+
+// application.yml comment
+# batch size is 100
+```
+
+---
+
+## DDD Alignment
+
+The domain layer is the core of PayFlow. It has no knowledge of Spring, JPA, Kafka, or any framework. Business rules live in aggregates — nothing outside the aggregate root mutates its internal state.
+
+**✅ Good**
+```java
+// domain/model/Payment.java — zero framework imports
+public class Payment {
+    private UUID id;
+    private PaymentStatus status;
+    private long amountCents;
+    private final List<DomainEvent> uncommittedEvents = new ArrayList<>();
+
+    // Aggregate enforces its own invariants
+    public void complete() {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new InvalidPaymentStateTransitionException(this.id, this.status, PaymentStatus.COMPLETED);
+        }
+        this.status = PaymentStatus.COMPLETED;
+        recordEvent(new PaymentCompleted(this.id, this.amountCents));
+    }
+
+    public List<DomainEvent> domainEvents() {
+        return List.copyOf(uncommittedEvents);
+    }
+}
+```
+
+**❌ Bad**
+```java
+// External code mutating aggregate state — aggregate has no say
+Payment payment = paymentRepository.findById(paymentId);
+
+if (payment.getStatus().equals("PENDING")) {
+    payment.setStatus("COMPLETED");         // setter bypasses all invariant checks
+    payment.setUpdatedAt(Instant.now());    // aggregate state changed from outside
+    paymentRepository.save(payment);
+}
+```
+
+---
+
+## Fail Fast
+
+Validate at the boundary. Reject invalid input before it touches the domain. Inside the domain, throw immediately on invariant violation — never return null, never set a flag, never swallow the error silently.
+
+**✅ Good**
+```java
+// DTO validation rejects bad input at the HTTP boundary
+public record InitiatePaymentRequest(
+    @NotNull UUID sourceAccountId,
+    @NotNull UUID targetAccountId,
+    @Positive long amountCents
+) {}
+
+// Domain throws immediately on invariant violation — no silent failures
+public static Payment initiate(UUID sourceAccountId, UUID targetAccountId, long amountCents) {
+    if (amountCents <= 0) throw new InvalidPaymentAmountException(amountCents);
+    if (sourceAccountId.equals(targetAccountId)) throw new SelfTransferException(sourceAccountId);
+    // ...
+}
+```
+
+**❌ Bad**
+```java
+// Silent failure — caller has no idea the payment wasn't created
+public Optional<Payment> initiate(InitiatePaymentCommand cmd) {
+    if (cmd.amountCents() <= 0) return Optional.empty(); // fail silently
+    // ...
+}
+
+// No boundary validation — invalid data reaches the domain
+@PostMapping("/payments")
+public ResponseEntity<?> initiate(@RequestBody Map<String, Object> body) {
+    long amount = (long) body.get("amount"); // no validation, ClassCastException in prod
+    // ...
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,21 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.13.0</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,13 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
             <version>0.13.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
             <version>0.13.0</version>
+            <scope>runtime</scope>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/payflow/domain/model/user/User.java
+++ b/src/main/java/com/payflow/domain/model/user/User.java
@@ -54,7 +54,7 @@ public class User implements UserDetails {
 
     @Override
     public @Nullable String getPassword() {
-        return "";
+        return passwordHash;
     }
 
     @Override

--- a/src/main/java/com/payflow/domain/model/user/User.java
+++ b/src/main/java/com/payflow/domain/model/user/User.java
@@ -7,10 +7,16 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 
 import java.time.LocalDateTime;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -18,7 +24,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User implements UserDetails {
     @Id
     @UuidGenerator
     private UUID id;
@@ -40,4 +46,39 @@ public class User {
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public @Nullable String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/payflow/infrastructure/security/JwtService.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtService.java
@@ -51,7 +51,8 @@ public class JwtService {
     }
 
     private boolean isTokenExpired(String token) {
-        return extractExpiration(token).before(new Date());
+        Date expiration = extractExpiration(token);
+        return expiration == null || expiration.before(new Date());
     }
 
     public String extractUsername(String token) {

--- a/src/main/java/com/payflow/infrastructure/security/JwtService.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtService.java
@@ -1,0 +1,83 @@
+package com.payflow.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+
+    @Value("${app.jwt.secret}")
+    private String jwtSecret;
+    @Value("${app.jwt.expiration}")
+    private long jwtExpiration;
+
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateAccessToken(Map.of(), userDetails);
+    }
+    public String generateAccessToken(
+            Map<String, Object> extraClaims,
+            UserDetails userDetails) {
+        return Jwts
+                .builder()
+                .claims(extraClaims)
+                .subject(userDetails.getUsername())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis()+jwtExpiration))
+                .signWith(getSignInKey(), Jwts.SIG.HS256).compact();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        try {
+            final String username = extractUsername(token);
+            if (username == null) return false;
+            return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+        } catch (JwtException | IllegalArgumentException _) {
+            return false;
+        }
+    }
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        if (claims == null) return null;
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSignInKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (JwtException | IllegalArgumentException _) {
+            return null;
+        }
+    }
+
+     SecretKey getSignInKey() {
+        byte[] decodedKey = Base64.getDecoder().decode(jwtSecret);
+        return Keys.hmacShaKeyFor(decodedKey);
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/security/JwtServiceTest.java
+++ b/src/test/java/com/payflow/infrastructure/security/JwtServiceTest.java
@@ -1,0 +1,60 @@
+package com.payflow.infrastructure.security;
+
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.user.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Date;
+import io.jsonwebtoken.Jwts;
+import org.springframework.test.util.ReflectionTestUtils;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    private UserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "jwtSecret",
+                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMjU2LWJpdHMtbG9uZwo=");
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", 900000L);
+
+        userDetails = User.builder()
+                .email("test@payflow.com")
+                .passwordHash("hashed")
+                .fullName("Test User")
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    void shouldGenerateValidTokenAndExtractUsername() {
+        String token = jwtService.generateAccessToken(userDetails);
+
+        assertThat(jwtService.validateToken(token, userDetails)).isTrue();
+        assertThat(jwtService.extractUsername(token)).isEqualTo("test@payflow.com");
+    }
+
+    @Test
+    void shouldReturnFalseForTamperedToken() {
+        String token = jwtService.generateAccessToken(userDetails);
+        String tampered = token.substring(0, token.length() - 5) + "XXXXX";
+
+        assertThat(jwtService.validateToken(tampered, userDetails)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForExpiredToken() {
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", -1000L);
+        String token = jwtService.generateAccessToken(userDetails);
+
+        assertThat(jwtService.validateToken(token, userDetails)).isFalse();
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/security/JwtServiceTest.java
+++ b/src/test/java/com/payflow/infrastructure/security/JwtServiceTest.java
@@ -4,13 +4,9 @@ import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.user.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import static org.assertj.core.api.Assertions.assertThat;
-import java.util.Date;
-import io.jsonwebtoken.Jwts;
 import org.springframework.test.util.ReflectionTestUtils;
-import static org.junit.jupiter.api.Assertions.*;
 
 
 class JwtServiceTest {


### PR DESCRIPTION
## What
Adds `JwtService` for HS256 JWT token generation, validation, and claim extraction, backed by a configurable secret and expiration.

## Linked Issue
Closes #7 

## Why
Stateless authentication via JWT is required before any protected endpoints can be built. Centralising token logic in `JwtService` ensures the future authentication filter and auth endpoints share one implementation rather than duplicating crypto code.

## Changes
- **`infrastructure/security/JwtService`** — generates HS256 access tokens with `@Value`-injected secret and expiration; validates tokens against `UserDetails`; extracts claims with null-safe error handling (`JwtException` caught, returns `null`/`false` instead of throwing)
- **`JwtServiceTest`** — unit tests covering happy path (generate + validate + extract username), tampered signature, and expired token

## Testing
- `JwtServiceTest` — plain unit test (no Spring context), uses `ReflectionTestUtils` to inject secret and expiration
- Covers: valid token round-trip, tampered signature returns `false`, expired token returns `false`

## Notes
- `JwtAuthenticationFilter` wiring is a follow-up — will set `SecurityContextHolder` once `UserDetailsService` and `SecurityConfig` land