### PR TITLE
Add unit tests for Wallet domain and query handler

### DIFF
--- a/src/test/java/com/payflow/application/query/wallet/WalletQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/wallet/WalletQueryHandlerTest.java
@@ -1,0 +1,52 @@
+package com.payflow.application.query.wallet;
+
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletAccessDeniedException;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.infrastructure.persistence.jpa.WalletRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletQueryHandlerTest {
+
+    @Mock
+    WalletRepository walletRepository;
+
+    @InjectMocks
+    WalletQueryHandler walletQueryHandler;
+
+    @Test
+    void handle_shouldThrowWhenWalletNotFound() {
+        // Given
+        when(walletRepository.findById(any())).thenReturn(Optional.empty());
+
+        // When + Then
+        assertThatThrownBy(() ->
+                walletQueryHandler.handle(new GetWalletByIdQuery(UUID.randomUUID(), UUID.randomUUID())))
+                .isInstanceOf(WalletNotFoundException.class);
+    }
+
+    @Test
+    void handle_shouldThrowWhenWalletBelongsToDifferentUser() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("EUR"));
+        when(walletRepository.findById(any())).thenReturn(Optional.of(wallet));
+
+        // When + Then
+        assertThatThrownBy(() ->
+                walletQueryHandler.handle(new GetWalletByIdQuery(wallet.getId(), UUID.randomUUID())))
+                .isInstanceOf(WalletAccessDeniedException.class);
+    }
+}

--- a/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
+++ b/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
@@ -1,0 +1,24 @@
+package com.payflow.domain.model.wallet;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+class WalletTest {
+
+    @Test
+    void create_shouldCreateWalletWithZeroBalance() {
+        //When
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+
+        //Then
+        assertThat(wallet.getCurrentBalance()).isEqualTo(BigDecimal.ZERO);
+        assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ACTIVE);
+        assertThat(wallet.getCurrency()).isEqualTo(Currency.getInstance("GBP"));
+    }
+}


### PR DESCRIPTION
## What
Add Mockito-based unit tests for the `Wallet` aggregate and `WalletQueryHandler`, covering creation invariants and access-control failure paths.

## Linked Issue
Closes #19

## Why
The Wallet domain had zero test coverage. Without tests, regressions in balance initialisation, status defaults, and per-user access enforcement go undetected.

## Changes
- **domain/** — `WalletTest`: verifies `Wallet.create()` produces zero balance, ACTIVE status, and correct currency
- **application/query/wallet/** — `WalletQueryHandlerTest`: covers `WalletNotFoundException` when repo returns empty, and `WalletAccessDeniedException` when wallet owner differs from requesting user

## Testing
- `WalletTest` — plain unit test, no Spring context
- `WalletQueryHandlerTest` — Mockito `@ExtendWith(MockitoExtension.class)`, `WalletRepository` mocked
- Failure cases: not-found path, cross-user access attempt