### PR TITLE
Add Week 1 ADRs (ADR-001 through ADR-013)

### DIFF
--- a/docs/adr/ADR-001-flyway-over-liquibase.md
+++ b/docs/adr/ADR-001-flyway-over-liquibase.md
@@ -1,0 +1,54 @@
+# ADR-001: Flyway over Liquibase for Schema Migrations
+
+## Status
+Accepted — Week 1 (Implementation of Kafka deferred for Week 2)
+
+## Context
+PayFlow requires a database migration tool to manage PostgreSQL schema evolution
+across environments (local Docker, CI, production). The two dominant
+options in the Spring Boot ecosystem are Flyway and Liquibase.
+
+Schema migrations in a financial system are high-stakes — incorrect or
+partially applied migrations can corrupt ledger data or break double-entry
+invariants. The tool must be reliable, auditable, and operationally simple.
+
+## Decision
+Use Flyway with SQL-based migrations (`V{version}__{description}.sql`).
+Hibernate `ddl-auto` is set to `validate` — Flyway owns the schema entirely,
+Hibernate never touches DDL.
+
+## Alternatives Considered
+
+**Liquibase**
+- Supports XML, YAML, JSON, and SQL changelog formats
+- More expressive rollback support out of the box
+- Higher conceptual surface area — changelogs, changesets, contexts, labels
+- XML/YAML format adds abstraction between intent and actual SQL
+
+**Flyway**
+- Pure SQL migrations — what you write is exactly what runs
+- Linear versioning (`V1`, `V2`, ...) enforces a clear migration history
+- Simpler mental model with less configuration
+- Native Spring Boot autoconfiguration with minimal setup
+- Checksum validation catches accidental migration edits
+
+## Rationale
+For a financial system, **auditability and predictability outweigh flexibility**.
+Flyway's SQL-first approach means migrations are readable by anyone with SQL
+knowledge, diff cleanly in Git, and leave no ambiguity about what ran against
+the database.
+
+Liquibase's rollback support is its strongest argument, but automatic rollbacks
+in a financial system are dangerous — a failed migration should be fixed forward
+with a new migration, not rolled back automatically. This eliminates Liquibase's
+primary advantage.
+
+The lower operational complexity of Flyway also reduces the risk of
+misconfiguration in a solo-developed project where cognitive overhead matters.
+
+## Consequences
+- Migrations are plain SQL files — immediately readable and reviewable
+- `ddl-auto: validate` means Hibernate will fail fast on startup if the schema
+  doesn't match the entity model, catching drift early
+- No rollback support — all fixes go forward via new migrations
+- Migration filenames follow strict convention: `V{N}__{snake_case_description}.sql`

--- a/docs/adr/ADR-002-apache-kafka over confluentinc-cp-kafka.md
+++ b/docs/adr/ADR-002-apache-kafka over confluentinc-cp-kafka.md
@@ -1,0 +1,50 @@
+# ADR-002: apache/kafka over confluentinc/cp-kafka as the Kafka Docker image
+
+## Status
+Accepted — Week 1 
+
+## Context
+PayFlow requires a Kafka broker running in Docker Compose for local development
+and CI. The two most common images are the official Apache Kafka image
+(`apache/kafka`) and Confluent's distribution (`confluentinc/cp-kafka`).
+
+Both support KRaft mode (no ZooKeeper). The choice affects licensing,
+configuration complexity, and how closely the local environment mirrors
+a potential production deployment.
+
+## Decision
+Use `apache/kafka` with KRaft mode. No ZooKeeper. No Confluent Platform
+dependency.
+
+## Alternatives Considered
+
+**confluentinc/cp-kafka**
+- Confluent's distribution, widely used in production
+- Bundles Confluent Platform tooling (Schema Registry, Control Center, etc.)
+- Well-documented KRaft setup
+- Confluent Community License restricts use in competing SaaS products
+- Heavier image — includes tooling PayFlow doesn't need
+
+**apache/kafka**
+- Official ASF image under Apache 2.0 license
+- No license restrictions
+- Minimal image — only what Kafka needs
+- KRaft supported natively since Kafka 3.3+
+
+## Rationale
+PayFlow has no dependency on Confluent Platform tooling. Schema Registry,
+Control Center, and ksqlDB are out of scope for this project. Pulling in
+`confluentinc/cp-kafka` would introduce a heavier image and a more restrictive
+license for no functional benefit.
+
+`apache/kafka` under Apache 2.0 is the correct choice for a project that only
+needs a Kafka broker. It keeps the Docker Compose stack lean and avoids any
+licensing ambiguity.
+
+## Consequences
+- Docker Compose stack stays minimal — no Confluent Platform overhead
+- Apache 2.0 license — no restrictions on use or distribution
+- KRaft configuration must be done manually without Confluent's convenience
+  wrappers, but this is well-documented for `apache/kafka` as of 3.9.0
+- No access to Confluent tooling locally — acceptable since PayFlow doesn't
+  use Schema Registry or Control Center

--- a/docs/adr/ADR-003-user-implements-userdetails-directly.md
+++ b/docs/adr/ADR-003-user-implements-userdetails-directly.md
@@ -1,0 +1,49 @@
+# ADR-003: User implements UserDetails directly over a UserDetailsImpl wrapper
+
+## Status
+Accepted Week 1
+
+## Context
+`UserDetails` object is required for Spring to perform
+Authentication. There are two standard approaches to
+provide that: have a domain `User` entity implement
+`UserDetails` directly, or create a separate `UserDetailsImpl` wrapper
+class that adapts `User` to the `UserDetails` interface.
+
+## Decision
+`User` implements `UserDetails` directly.
+
+## Alternatives Considered
+
+**UserDetails wrapper**
+- A separate class implements `UserDetails` and has reference to a `User`
+- Domain `User` without Security dependency
+- Stricter DDD - infrastructure details don't leak into the domain model
+- Requires extra class and mapping
+- More boilerplate for no functional difference and advantage
+
+**User implements UserDetails directly**
+- `User` carries annotations from Spring Security
+- One class less - `UserDetailsServiceConfig` returns the `User` directly
+- Spring Security leaks into the domain layer as a compile-time dependency
+- Pragmatic for a project where `User` is not a pure aggregate
+
+## Rationale
+`User` is intentionally a plain `@Entity` rather than a full DDD
+aggregate — this was already established in ADR-009. Given that `User` carries
+no domain invariants and no business logic worth protecting from framework
+coupling, the strict separation a wrapper provides has no practical payoff here.
+
+The wrapper pattern earns its complexity when the domain `User` has rich
+behavior that must be tested in isolation from Spring Security. PayFlow's `User`
+does not — it is essentially a credential and identity record. Adding
+`UserDetailsImpl` would be indirection for its own sake.
+
+This is revisited if `User` grows domain behavior that warrants isolation.
+
+## Consequences
+- Spring Security is a compile-time dependency of the domain `User` class
+- `UserDetailsServiceConfig` is simpler — loads `User` from the repository
+  and returns it directly
+- Unit testing `User` requires Spring Security on the classpath
+- Acceptable tradeoff given `User`'s role as a plain entity in this architecture

--- a/docs/adr/ADR-004-wallet-balance-cached-ledger-source-of-truth.md
+++ b/docs/adr/ADR-004-wallet-balance-cached-ledger-source-of-truth.md
@@ -1,0 +1,61 @@
+# ADR-004: Wallet balance as cached field, ledger as source of truth
+
+## Status
+Accepted — Week 1 (credit/debit implementation deferred to Week 3)
+
+## Context
+System plans to use a double-entry ledger to record every financial movement as
+immutable `LedgerEntry` rows. (see why in future ADR) This raises a question: when the current balance
+of a wallet is needed, should it be derived by summing ledger entries at query
+time, or maintained as a cached field on the `Wallet` entity itself?
+
+Balance reads are frequent — every transaction, every balance check, every
+UI render. The choice affects read performance, data consistency guarantees,
+and the complexity of the write path.
+
+## Decision
+Maintain `current_balance` as a cached field on the `Wallet` entity, updated
+atomically with each credit or debit. The ledger remains the source of truth —
+`current_balance` is always derivable by summing the wallet's ledger entries.
+
+## Alternatives Considered
+
+**Derive balance from ledger at query time**
+- No cached state — balance is always mathematically correct by definition
+- Eliminates any possibility of cache/ledger divergence
+- Read performance degrades as ledger grows — full table scan per balance check
+- Unacceptable for a payment system where balance reads are on the hot path
+
+**Cached balance on Wallet (chosen)**
+- `current_balance` updated atomically within the same transaction as the
+  ledger entry write
+- O(1) balance reads regardless of ledger size
+- Requires `@Version` optimistic locking to prevent concurrent update anomalies
+- Cache can theoretically diverge from ledger if a bug bypasses the domain model
+  — mitigated by making direct balance mutation impossible outside `credit()`
+  and `debit()`
+
+## Rationale
+It is not scalable to sum up ledger entries on each read. For a single balance check,
+a wallet with years of transaction history would need to aggregate thousands of rows.
+Financial systems typically keep an immutable ledger and a running balance for this reason.
+
+The consistency risk is real but manageable. By making sure that `current_balance` can only 
+be changed by `Wallet.credit()` and `Wallet.debit()`—never directly—and by writing the ledger 
+entry and updating the balance in the same SERIALISABLE transaction, divergence can only happen
+if there is a bug that completely skips the domain model. A periodic reconciliation job can detect and alert on any
+divergence.
+
+## Consequences
+- Balance reads are O(1) — no ledger aggregation on the hot path
+- `Wallet.credit()` and `Wallet.debit()` are the only mutation points —
+  enforced by domain model design, not database constraints
+- `@Version` optimistic locking on `Wallet` guards against lost updates
+  under concurrent transactions (see ADR-008)
+- SERIALIZABLE isolation on credit/debit handlers ensures ledger entry and
+  balance update are atomic (see ADR-011)
+- A reconciliation job comparing `current_balance` against summed ledger
+  entries is deferred — frequency and alerting strategy to be decided
+
+
+

--- a/docs/adr/ADR-005-stateless-jwt-stateful-refresh-tokens-deffered.md
+++ b/docs/adr/ADR-005-stateless-jwt-stateful-refresh-tokens-deffered.md
@@ -1,0 +1,62 @@
+# ADR-005: Stateless JWT, stateful refresh tokens deferred to Week 3
+
+## Status
+Accepted — Week 1 (stateful refresh token implementation deferred to Week 3)
+
+## Context
+Authentication requires issuing tokens that prove identity on subsequent
+requests. Two separate but related concerns could be used here:
+the access token strategy and the refresh token strategy.
+
+Access tokens can be stateless (self-contained, verified by signature alone)
+or stateful (verified against a server-side store on every request). Refresh
+tokens can be single-use stateful (stored, invalidated on use) or stateless
+(long-lived JWTs with no server-side record).
+
+The choice affects security guarantees, infrastructure complexity, and the
+ability to revoke tokens without a server-side store.
+
+## Decision
+Issue stateless JWTs as access tokens. Refresh tokens are also stateless in
+Week 1 — no server-side store. Stateful refresh tokens with a database-backed
+revocation mechanism are deferred to Week 3.
+
+## Alternatives Considered
+
+**Stateful access tokens**
+- Every request hits a server-side store  to validate the token
+- Instant revocation — invalidate the record, token is dead immediately
+- Adds a network hop and infrastructure dependency to every authenticated request
+- Overkill for access tokens with short TTLs
+
+**Stateless JWT access tokens (chosen)**
+- Self-contained — signature verification only, no server-side lookup
+- Cannot be revoked before expiry — mitigated by keeping TTL short (15 minutes)
+- No infrastructure dependency on the hot authentication path
+- Standard approach for access tokens in stateless REST APIs
+
+**Stateful refresh tokens (deferred)**
+- Stored in the database, single-use, invalidated on rotation
+- Enables logout, token family detection, and revocation
+- Correct long-term security posture for a payment system
+- Requires a `refresh_tokens` table and rotation logic — deferred to Week 3
+
+## Rationale
+Stateless JWTs are the correct choice for access tokens. A 15-minute TTL
+limits the damage window of a leaked token without requiring infrastructure
+to support revocation on the hot path.
+
+Stateful refresh tokens are the correct long-term choice but introduce
+meaningful implementation complexity — token rotation, family invalidation,
+and secure storage. Deferring this to Week 3 keeps Week 1 focused on core
+authentication flow without compromising the access token security model.
+
+The Week 1 stateless refresh token is a known temporary compromise, not
+a permanent decision.
+
+## Consequences
+- Access tokens expire in 15 minutes — clients must refresh proactively
+- No logout invalidation in Week 1 — tokens remain valid until expiry
+- No token revocation on compromise in Week 1 — acceptable given short TTL
+- Week 3 introduces a `refresh_tokens` table, single-use rotation, and
+  token family invalidation to replace the stateless refresh approach

--- a/docs/adr/ADR-006-HS256-over-RS256.md
+++ b/docs/adr/ADR-006-HS256-over-RS256.md
@@ -1,0 +1,56 @@
+# ADR-006: HS256 over RS256 for JWT signing
+
+## Status
+Accepted — Week 1
+
+## Context
+JWTs must be signed to prevent tampering. There are two mainstream signing strategies
+that are HMAC-based symmetric signing (HS256) and RSA-based asymmetric signing
+(RS256). The choice affects key management complexity, verification architecture,
+and operational overhead.
+
+## Decision
+Use HS256 — a shared secret signs and verifies all tokens. A single secret
+key is configured via environment variable.
+
+## Alternatives Considered
+
+**RS256 (asymmetric)**
+- Private key signs tokens, public key verifies them
+- Public key can be distributed freely — enables external services to verify
+  tokens without access to the signing secret
+- Necessary in multiservice architectures where different services need to
+  verify tokens independently
+- Requires key pair generation, rotation strategy, and JWTS endpoint exposure
+- Significantly more operational complexity for no benefit in a monolith
+
+**HS256 (chosen)**
+- Single shared secret signs and verifies tokens
+- Simple key management — one environment variable
+- Verification requires access to the secret — acceptable when only one service
+  verifies tokens
+- Standard choice for monolithic architectures
+
+## Rationale
+RS256 earns its complexity in distributed systems where multiple independent
+services verify tokens without sharing a secret. PayFlow is a monolith — the
+same service that issues tokens also verifies them. There is no external
+consumer of the JWT that needs the public key.
+
+HS256 with a strong secret and short token TTL (see ADR-005) provides
+adequate security for this architecture with significantly lower operational
+overhead.
+
+If PayFlow evolves into a multiservice architecture where separate services
+need to verify tokens independently, migrating to RS256 with a JWTS endpoint
+is the natural next step.
+
+## Consequences
+- JWT signing and verification happen within the same service — secret never
+  leaves the backend
+- Secret must be sufficiently long and random — enforced via environment
+  variable, never hardcoded
+- Key rotation requires reissuing all active tokens — acceptable given the
+  15-minute access token TTL from ADR-005
+- Migration to RS256 is straightforward if the architecture becomes
+  multiservice

--- a/docs/adr/ADR-007-UUID-over-auto-increment-primary-keys.md
+++ b/docs/adr/ADR-007-UUID-over-auto-increment-primary-keys.md
@@ -1,0 +1,63 @@
+# ADR-007: UUID over auto-increment primary keys
+
+## Status
+Accepted — Week 1
+
+## Context
+Every entity in the system requires a primary key strategy. The two standard
+options are auto-increment integers (sequential, database-generated) and UUIDs
+(universally unique, generatable anywhere). The choice affects key predictability,
+distribution safety, and application-layer ID generation.
+
+Financial systems have additional considerations — sequential IDs expose
+business intelligence (transaction volume, user count) and are trivially
+enumerable by an attacker.
+
+## Decision
+Use UUID v4 for all primary keys, generated at object construction time in Java via Hibernate's `@UuidGenerator`. Mapped as `UUID` in Java, stored as native `uuid` type
+in PostgreSQL.
+
+## Alternatives Considered
+
+**Auto-increment integers**
+- Simple, human-readable, naturally ordered
+- Sequential — exposes record counts and growth rate to anyone who can observe
+  IDs
+- Enumerable — an attacker can iterate `GET /api/wallets/1`, `/2`, `/3`
+- Tightly coupled to the database — ID only exists after an insert
+- Problematic in future distributed or multi-database scenarios
+
+**UUID v4 (chosen)**
+- Non-sequential, non-enumerable — no business intelligence leakage
+- Globally unique — safe across databases, environments, and future shards
+- Can be generated before the database insert — useful for Outbox pattern
+  where the aggregate ID must be known before persistence
+- Native `uuid` type in PostgreSQL — no storage penalty over a string
+- No meaningful human-readability loss in a system where IDs are never
+  user-facing
+
+## Rationale
+Sequential IDs are a liability in a financial system. Exposing user count
+or transaction volume through observable IDs is an information leak that
+has no upside. UUID v4 eliminates this entirely.
+
+The more important reason for PayFlow specifically is the Outbox pattern
+(see future ADR). The Outbox requires embedding the aggregate ID in the domain
+event before the transaction commits. Auto-increment IDs are not available
+until after the insert — UUIDs can be assigned at object construction time,
+making them a natural fit for event-driven architectures.
+
+`@UuidGenerator` generates the UUID in the Java domain object before
+persistence — the ID exists at construction time, satisfying the Outbox
+requirement of knowing the aggregate ID before the transaction commits.
+
+## Consequences
+- Primary keys are non-enumerable — direct object access requires a valid UUID
+- IDs are available at object construction time — compatible with Outbox
+  pattern and domain event design
+- No natural sort order by insertion time — use `created_at` for ordering,
+  not the ID
+- UUIDs are 128-bit — slightly larger than 64-bit bigint, negligible at
+  PayFlow's scale
+- Human debugging is slightly harder — mitigated by always logging
+  correlation IDs alongside UUIDs

--- a/docs/adr/ADR-008-optimistic-locking-over-pessimistic-locking-on-wallet.md
+++ b/docs/adr/ADR-008-optimistic-locking-over-pessimistic-locking-on-wallet.md
@@ -1,0 +1,62 @@
+# ADR-008: Optimistic locking over pessimistic locking on Wallet
+
+## Status
+Accepted — Week 1 (credit/debit implementation deferred to Week 3)
+
+## Context
+`Wallet` is the central aggregate in the system. Every credit and debit operation
+performs a read-modify-write on `current_balance` — a classic concurrency
+hazard. Without a locking strategy, two concurrent transactions can read the
+same balance, both apply their modification, and one update silently overwrites
+the other (lost update anomaly).
+
+Two standard strategies exist: optimistic locking (detect conflicts at commit
+time) and pessimistic locking (prevent concurrent access at read time).
+
+## Decision
+Use `@Version` optimistic locking on `Wallet`. Hibernate manages the version
+column — every write increments it, and a stale version at commit time throws
+`ObjectOptimisticLockingFailureException`, mapped to HTTP 409.
+
+## Alternatives Considered
+
+**Pessimistic locking (`SELECT FOR UPDATE`)**
+- Locks the wallet row at read time — no concurrent transaction can read or
+  write until the lock is released
+- Guarantees no conflict — but at the cost of throughput
+- Long-running transactions hold the lock for their entire duration
+- Risk of deadlock when multiple wallets are involved in one transaction
+- Appropriate when conflict rate is high and retry cost is prohibitive
+
+**Optimistic locking (`@Version`) (chosen)**
+- No lock held during the transaction — full read concurrency
+- Conflict detected at commit time via version check
+- Failed commit throws `ObjectOptimisticLockingFailureException` — client
+  retries the operation
+- Higher throughput under low-to-moderate contention
+- Appropriate when conflict rate is low and retry cost is acceptable
+
+## Rationale
+A payment system has high read concurrency but relatively low write contention
+per individual wallet. Two transactions targeting the exact same wallet at the
+exact same millisecond is the exception, not the rule. Pessimistic locking
+would serialize all writes to a wallet regardless of whether a conflict would
+actually occur — killing throughput for a problem that rarely materializes.
+
+Optimistic locking pays its cost only when a conflict actually happens. The
+client retries, which is the correct behavior for a transient concurrency
+failure. This is the standard approach for financial aggregates at PayFlow's
+scale.
+
+SERIALIZABLE isolation (see ADR-011) handles the broader anomaly prevention.
+`@Version` handles the lost update hazard specifically on `Wallet` writes.
+The two work together.
+
+## Consequences
+- `wallets` table has a `version` column managed by Hibernate
+- Concurrent modifications to the same wallet result in a 409 — not a 500
+- Clients must implement retry logic for 409 on wallet operations
+- `ObjectOptimisticLockingFailureException` is mapped to HTTP 409 in the
+  global exception handler
+- Under high contention on a single wallet, retry storms are theoretically
+  possible — acceptable at PayFlow's scale

--- a/docs/adr/ADR-009-hybrid-DDD-wallet-aggregate-model-user-plain.md
+++ b/docs/adr/ADR-009-hybrid-DDD-wallet-aggregate-model-user-plain.md
@@ -1,0 +1,67 @@
+# ADR-009: Hybrid DDD — aggregate model for Wallet, plain entity for User
+
+## Status
+Accepted — Week 1 (credit/debit implementation deferred to Week 3)
+
+## Context
+System's domain contains two primary entities: `Wallet` and `User`. Full DDD
+prescribes that all domain objects are modeled as aggregates with rich behavior,
+domain invariants enforced at the model level, and no framework imports in the
+domain layer.
+
+However, DDD purity has a cost — additional abstraction, more classes, and
+stricter separation that only pays off when the protected domain object has
+behavior worth isolating. The question is whether to apply full DDD uniformly
+or selectively based on where the complexity actually lives.
+
+## Decision
+Apply full DDD aggregate modeling to `Wallet`. Treat `User` as a plain JPA
+`@Entity` with no domain behavior. Future `LedgerEntry` and `AuditLog` are also
+plain entities — append-only records with no behavior to protect.
+
+## Alternatives Considered
+
+**Full DDD across all entities**
+- Consistent modeling — every entity follows the same pattern
+- Domain repository interfaces, factory methods, and domain events everywhere
+- `User` would have no domain invariants to enforce — abstraction with no payoff
+- Significant boilerplate for entities that are essentially data records
+
+**Plain JPA entities across all entities**
+- Simple, pragmatic — all entities are `@Entity` with direct `JpaRepository`
+- No domain layer separation — Spring Data and JPA leak everywhere
+- Loses the invariant enforcement that makes `Wallet` safe under concurrency
+- Ousterhout: shallow classes everywhere signal over-decomposition
+
+**Hybrid DDD (chosen)**
+- Full aggregate model where domain complexity exists (`Wallet`)
+- Plain `@Entity` where it doesn't (`User`, `LedgerEntry`, `AuditLog`)
+- Complexity matches the model — no abstraction without justification
+
+## Rationale
+`Wallet` has real domain invariants worth protecting:
+- Balance must never go negative
+- Mutations only through `credit()` and `debit()`
+- Concurrency safety via `@Version`
+- Domain events emitted on state change
+
+`User` has none of these. It is a credential and identity record — an email,
+a password hash, a role. There are no business rules that require protecting
+`User` behind a domain model. Applying full DDD to `User` would produce a
+shallow aggregate with no behavior, which Ousterhout identifies as the exact
+failure mode of over-decomposition.
+
+The hybrid approach follows the principle that architecture should match
+complexity. Full DDD where the domain is rich, plain entities where it is not.
+
+## Consequences
+- `Wallet` enforces all invariants internally — no service layer can mutate
+  balance directly
+- `User` is a plain `@Entity` with Spring Security coupling acceptable
+  (see ADR-003)
+- `LedgerEntry` is append-only — no update or delete methods, enforced by
+  the domain model
+- If `User` grows domain behavior (e.g. account suspension rules, KYC state
+  machine), it is promoted to a full aggregate at that point
+- Inconsistent modeling across entities is a known tradeoff — justified by
+  matching abstraction to actual complexity

--- a/docs/adr/ADR-010-static-factory-method-over-builder-on-aggregate-roots.md
+++ b/docs/adr/ADR-010-static-factory-method-over-builder-on-aggregate-roots.md
@@ -1,0 +1,65 @@
+# ADR-010: Static factory method over @Builder on aggregate roots
+
+## Status
+Accepted — Week 1
+
+## Context
+Aggregate roots require controlled construction — invariants must be enforced
+at the point of creation, not left to the caller to satisfy. Two common
+approaches in Java are Lombok's `@Builder` and static factory methods.
+
+The choice affects how strongly the aggregate can enforce its own invariants
+at construction time and how readable the intent of construction is at the
+call site.
+
+## Decision
+Use static factory methods (e.g. `Wallet.create()`) on aggregate roots.
+`@Builder` is permitted on DTOs and value objects where invariant enforcement
+is not a concern.
+
+## Alternatives Considered
+
+**Lombok @Builder**
+- Generates a fluent builder — readable at the call site
+- Any subset of fields can be set — caller decides which fields to populate
+- No natural place to enforce invariants — validation must happen externally
+  or in a separate method after construction
+- A partially constructed aggregate can exist — `build()` does not guarantee
+  a valid object
+- Exposes internal field names as builder methods — couples callers to the
+  internal structure of the aggregate
+
+**Static factory method (chosen)**
+- Construction intent is explicit — `Wallet.create(userId, currency)` reads
+  as a domain operation, not object assembly
+- Invariants enforced inside the method before the object is returned —
+  no partially valid aggregate can escape
+- Parameters are minimal and meaningful — only what is required to create
+  a valid aggregate
+- Default state (e.g. `currentBalance = ZERO`, `status = ACTIVE`) is set
+  internally — callers cannot accidentally omit or override it
+
+## Rationale
+`@Builder` is a construction convenience, not a domain modeling tool. It
+optimizes for flexibility at the call site at the cost of invariant safety.
+For a DTO where any combination of fields is valid, that tradeoff is
+acceptable. For an aggregate root where invalid state must be impossible,
+it is not.
+
+`Wallet.create(userId, currency)` enforces that every `Wallet` starts with
+`currentBalance = ZERO` and `status = ACTIVE`. There is no way to construct
+a `Wallet` with a non-zero opening balance or an invalid status through the
+factory method. `@Builder` provides no such guarantee — a caller could
+`builder().currentBalance(BigDecimal.valueOf(-100)).build()` and the aggregate
+would accept it silently.
+
+## Consequences
+- Every aggregate root has one or more named factory methods reflecting
+  domain intent
+- Invalid aggregate state is impossible to construct from outside the class
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)` used alongside the
+  factory method to satisfy JPA while keeping the public constructor blocked
+- `@Builder` remains available for DTOs, command objects, and value objects
+  where invariant enforcement is not required
+- Adding new required fields to an aggregate requires updating the factory
+  method signature — a compile-time break that is intentional, not a drawback

--- a/docs/adr/ADR-011-serializable-isolation-scoped-to-credit-debit.md
+++ b/docs/adr/ADR-011-serializable-isolation-scoped-to-credit-debit.md
@@ -1,0 +1,72 @@
+# ADR-011: SERIALIZABLE isolation scoped to credit/debit only, READ_COMMITTED for auth
+
+## Status
+Accepted — Week 1 (credit/debit implementation deferred to Week 3)
+
+## Context
+Spring's default transaction isolation level inherits from the database default,
+which in PostgreSQL is READ COMMITTED. Different operations in system have
+fundamentally different concurrency requirements — financial mutations on
+`Wallet` require strong isolation guarantees, while authentication operations
+are simple reads and writes with no meaningful concurrency hazard.
+
+Applying SERIALIZABLE globally would provide maximum safety but at significant
+throughput cost. The question is how to scope isolation levels appropriately
+across different operation types.
+
+## Decision
+Use SERIALIZABLE isolation exclusively on credit and debit command handlers.
+All other operations — authentication, wallet creation, balance reads — use
+READ COMMITTED (PostgreSQL default).
+
+## Alternatives Considered
+
+**SERIALIZABLE globally**
+- Maximum safety — no concurrency anomalies anywhere in the system
+- Significant throughput cost — SSI conflict detection overhead on every
+  transaction regardless of whether concurrency hazards exist
+- Auth operations (login, register) have no meaningful concurrency hazard —
+  SERIALIZABLE adds overhead with no safety benefit there
+- Overkill for operations that are not performing read-modify-write on
+  shared financial state
+
+**READ COMMITTED globally**
+- PostgreSQL default — minimal overhead, maximum throughput
+- Insufficient for credit/debit — vulnerable to lost update anomaly on
+  `current_balance` without additional protection
+- `@Version` alone partially mitigates this but SERIALIZABLE provides
+  stronger guarantees for financial mutations
+
+**Scoped isolation (chosen)**
+- SERIALIZABLE on `@Transactional` in credit/debit command handlers only
+- READ COMMITTED everywhere else
+- Isolation level matches the actual concurrency risk of each operation
+- No unnecessary overhead on auth and read operations
+
+## Rationale
+Isolation levels should match the concurrency hazards of the operation, not
+be applied uniformly for simplicity. Auth operations perform straightforward
+inserts and lookups — there is no read-modify-write, no shared mutable state,
+no meaningful anomaly to prevent. Applying SERIALIZABLE there wastes resources
+and increases abort rates for no safety gain.
+
+Credit and debit operations modify `current_balance` — shared mutable financial
+state that multiple concurrent transactions can target simultaneously. This is
+exactly the scenario SERIALIZABLE isolation exists for. Combined with `@Version`
+optimistic locking (ADR-008), concurrent wallet mutations are both detected and
+prevented at the isolation level.
+
+
+## Consequences
+- Credit/debit command handlers declare
+  `@Transactional(isolation = Isolation.SERIALIZABLE)` explicitly
+- All other `@Transactional` annotations use the default READ COMMITTED
+- PostgreSQL uses SSI (Serializable Snapshot Isolation) for SERIALIZABLE —
+  lower overhead than 2PL-based serializability but still non-zero
+- Serialization failures on credit/debit result in transaction abort and
+  retry — handled alongside `@Version` conflict retries
+- Auth throughput is unaffected by SERIALIZABLE overhead
+- Retry strategy for compounded SERIALIZABLE abort and @Version conflict
+    is deferred — a retry budget (max attempts) and exponential backoff
+    strategy will be defined in Week 3 when credit/debit handlers are
+    implemented. Unbounded retries under contention are a known risk

--- a/docs/adr/ADR-012-instant-over-localdatetime-for-timestamps.md
+++ b/docs/adr/ADR-012-instant-over-localdatetime-for-timestamps.md
@@ -1,0 +1,62 @@
+# ADR-012: Instant over LocalDateTime for all timestamps
+
+## Status
+Accepted — Week 1
+
+## Context
+Every entity in PayFlow records timestamps for creation and modification.
+Java offers multiple types for representing time — the two most common in
+Spring Boot applications are `LocalDateTime` (timezone-naive) and `Instant`
+(absolute point in time, UTC-based).
+
+Financial systems are particularly sensitive to timestamp correctness —
+audit trails, ledger entries, and transaction ordering all depend on
+unambiguous time representation.
+
+## Decision
+Use `Instant` for all timestamp fields across all entities. PostgreSQL
+columns are mapped as `TIMESTAMPTZ` (timestamp with time zone).
+
+## Alternatives Considered
+
+**LocalDateTime**
+- Human-readable, familiar to most Java developers
+- No timezone information — represents a wall clock time with no UTC offset
+- Stored as `TIMESTAMP WITHOUT TIME ZONE` in PostgreSQL by default
+- Ambiguous during DST transitions — the same `LocalDateTime` can represent
+  two different absolute moments
+- Dangerous in a financial system where timestamp ordering must be
+  unambiguous across timezones
+
+**Instant (chosen)**
+- Represents an absolute point in time — always UTC, no timezone ambiguity
+- Maps to `TIMESTAMPTZ` in PostgreSQL — timezone-aware storage
+- Unambiguous ordering — two `Instant` values always have a clear before/after
+  relationship
+- Correct type for audit trails, ledger timestamps, and transaction records
+- Slight reduction in human readability — mitigated by formatting at the
+  API response layer
+
+## Rationale
+`LocalDateTime` is the wrong type for a financial system. A timestamp without
+timezone information cannot unambiguously represent when something happened —
+it depends on the context of whoever reads it. For a ledger entry or audit
+record, that ambiguity is unacceptable.
+
+`Instant` removes the ambiguity entirely. Every timestamp is an absolute UTC
+moment. Ordering is deterministic regardless of where the server runs or
+where the client reads from. DST transitions cannot corrupt the audit trail.
+
+Formatting for human consumption happens at the API layer — `Instant` is
+serialized to ISO-8601 in responses, keeping the domain model correct and
+the API readable.
+
+## Consequences
+- All `createdAt` and `updatedAt` fields are `Instant` across all entities
+- All timestamp columns in Flyway migrations are defined as `TIMESTAMPTZ`,
+  never `TIMESTAMP` — enforced by convention across all migration files
+- `@CreationTimestamp` and `@UpdateTimestamp` populate `Instant` fields
+  correctly via Hibernate
+- API responses serialize `Instant` as ISO-8601 strings —
+  e.g. `2025-04-07T10:15:30Z`
+- No timezone conversion logic needed in the domain or persistence layer

--- a/docs/adr/ADR-013-wallet-repository-over-domain-repository-interface.md
+++ b/docs/adr/ADR-013-wallet-repository-over-domain-repository-interface.md
@@ -1,0 +1,63 @@
+# ADR-013: WalletRepository over domain repository interface until unit tests justify it
+## Status
+Accepted — Week 1
+To be refactored in Week 3 — WalletQueryHandlerTest already mocks
+WalletRepository directly, confirming the domain interface is now justified.
+
+## Context
+DDD prescribes that aggregates are accessed through domain repository interfaces
+defined in the domain layer, with infrastructure implementations in the
+persistence layer. This keeps the domain free of JPA and Spring Data imports
+and allows the repository to be mocked in unit tests without a database.
+
+However, defining a domain repository interface adds a layer of indirection
+that only pays off when unit tests actually mock it. The question is whether
+to add this abstraction upfront or defer it until the tests that justify it
+exist.
+
+## Decision
+`WalletRepository` extends `JpaRepository` directly in the persistence layer.
+No domain repository interface. No separate infrastructure implementation class.
+The repository is injected and used directly in command and query handlers.
+
+## Alternatives Considered
+
+**Domain repository interface (DDD canonical)**
+- `WalletRepository` interface defined in the domain layer with no JPA imports
+- `JpaWalletRepository` in the infrastructure layer implements it
+- Command handlers depend on the domain interface — fully mockable in unit tests
+- Correct long-term architecture for a DDD aggregate
+- Adds two classes and an interface per aggregate with no immediate payoff
+  if unit tests don't exist yet
+
+**Direct JpaRepository (chosen)**
+- `WalletRepository extends JpaRepository` lives in the persistence layer
+- Injected directly into command and query handlers
+- One class per aggregate — no indirection
+- JPA leaks into the application layer as a compile-time dependency
+- Justified while unit tests don't yet require mocking the repository
+- Refactoring to a domain interface is mechanical when the time comes
+
+## Rationale
+Abstraction without a current use case is speculative complexity. The domain
+repository interface earns its existence when a unit test needs to mock it.
+Until that test exists, the interface is indirection for its own sake.
+
+Week 1 has no Testcontainers integration tests and no unit tests that require
+mocking the repository. Adding the domain interface now would be building
+infrastructure for a future that hasn't arrived. The refactor from
+`WalletRepository extends JpaRepository` to a domain interface is mechanical
+and low-risk — it does not need to happen before the tests that motivate it
+exist.
+
+## Consequences
+- `WalletRepository` lives in the persistence layer — no domain interface,
+  no infrastructure implementation class
+- Spring Data JPA is a compile-time dependency of command and query handlers
+  in Week 1
+- Refactoring to domain repository interface is deferred to Week 3 alongside
+  Testcontainers and unit test introduction
+- The refactor is mechanical — extract interface, move to domain layer,
+  update injection points
+- All Week 1 repository usage goes through `JpaRepository` methods directly —
+  no custom repository methods that would complicate the future extraction


### PR DESCRIPTION
## What
Add all 13 Week 1 Architecture Decision Records to the repository, targeting `main` directly.

## Linked Issue
Closes #23

## Why
PR #24 was merged into `chore/ci-pipeline` instead of `main`, so issue #23 was never closed. This PR re-applies the same ADR commits against the correct base branch.

## Changes
- `docs/adr/ADR-001` — Flyway over Liquibase
- `docs/adr/ADR-002` — apache/kafka over confluentinc/cp-kafka
- `docs/adr/ADR-003` — User implements UserDetails directly
- `docs/adr/ADR-004` — Wallet balance as cached field, ledger as source of truth
- `docs/adr/ADR-005` — Stateless JWT, stateful refresh tokens deferred
- `docs/adr/ADR-006` — HS256 over RS256
- `docs/adr/ADR-007` — UUID over auto-increment PKs
- `docs/adr/ADR-008` — Optimistic locking over pessimistic locking on Wallet
- `docs/adr/ADR-009` — Hybrid DDD: aggregate model for Wallet, plain entity for User
- `docs/adr/ADR-010` — Static factory method over @Builder on aggregate roots
- `docs/adr/ADR-011` — SERIALIZABLE isolation scoped to credit/debit only
- `docs/adr/ADR-012` — Instant over LocalDateTime for timestamps
- `docs/adr/ADR-013` — WalletRepository direct JpaRepository until unit tests justify interface

## How to Test
- Documentation only — no runtime changes.

## Checklist
- [x] Code compiles with no errors
- [x] Tests written and passing
- [x] No hardcoded secrets or credentials
- [x] Acceptance criteria on linked issue all checked off
- [x] ADR written if this involved a major architectural decision