### PR TITLE
Fix Week 1 review blockers: money type, timestamps, exception handling, and @Transactional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 .vscode/
 
 .env*
+/src/main/resources/application-local.yml

--- a/src/main/java/com/payflow/api/dto/response/WalletResponse.java
+++ b/src/main/java/com/payflow/api/dto/response/WalletResponse.java
@@ -3,7 +3,6 @@ package com.payflow.api.dto.response;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletStatus;
 
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Currency;
 import java.util.UUID;
@@ -11,7 +10,7 @@ import java.util.UUID;
 public record WalletResponse(
         UUID id,
         Currency currency,
-        BigDecimal balance,
+        Long balance,
         WalletStatus status,
         Instant createdAt
 ) {

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.payflow.api.exception;
 
 import com.payflow.api.dto.response.ErrorResponse;
+import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.wallet.WalletAccessDeniedException;
 import com.payflow.domain.model.wallet.WalletNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -34,5 +35,11 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleWalletAccessDenied(WalletAccessDeniedException ex) {
         return new ErrorResponse("ACCESS_DENIED", ex.getMessage());
+    }
+
+    @ExceptionHandler(EmailAlreadyRegisteredException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handeDuplicateEmail(EmailAlreadyRegisteredException ex) {
+        return new ErrorResponse("EMAIL_ALREADY_REGISTERED", ex.getMessage());
     }
 }

--- a/src/main/java/com/payflow/application/command/RegisterCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/RegisterCommandHandler.java
@@ -1,17 +1,21 @@
+// TODO(Week 3): Move to LoginCommandHandler when stateful refresh tokens
+// introduce real DB writes — currently stateless so side effects are minimal.
+
 package com.payflow.application.command;
 
 import com.payflow.api.dto.response.AuthenticationResponse;
+import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.user.UserStatus;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.infrastructure.persistence.jpa.UserRepository;
 import com.payflow.infrastructure.persistence.jpa.WalletRepository;
 import com.payflow.infrastructure.security.JwtService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Currency;
 
@@ -27,7 +31,7 @@ public class RegisterCommandHandler {
     @Transactional // For future use, convention wise atm
     public AuthenticationResponse handle(RegisterCommand command) {
         if (userRepository.existsByEmail(command.email())) {
-            throw new BadCredentialsException(command.email());
+            throw new EmailAlreadyRegisteredException(command.email());
         }
         User user = User.builder()
                 .fullName(command.fullName())

--- a/src/main/java/com/payflow/application/query/AuthQueryHandler.java
+++ b/src/main/java/com/payflow/application/query/AuthQueryHandler.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class AuthQueryHandler {
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
 
+    @Transactional(readOnly = true)
     public AuthenticationResponse handle(AuthQuery query)
     {
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/payflow/domain/model/user/EmailAlreadyRegisteredException.java
+++ b/src/main/java/com/payflow/domain/model/user/EmailAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.payflow.domain.model.user;
+
+public class EmailAlreadyRegisteredException extends RuntimeException {
+    public EmailAlreadyRegisteredException(String email) {
+        super("Email already registered: " + email);
+    }
+}

--- a/src/main/java/com/payflow/domain/model/wallet/Wallet.java
+++ b/src/main/java/com/payflow/domain/model/wallet/Wallet.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
-import java.math.BigDecimal;
+
 import java.time.Instant;
 import java.util.Currency;
 import java.util.UUID;
@@ -27,7 +27,7 @@ public class Wallet {
     private Currency currency;
 
     @Column(nullable = false, precision = 19, scale = 4)
-    private BigDecimal currentBalance;
+    private Long currentBalance;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
@@ -47,7 +47,7 @@ public class Wallet {
         Wallet wallet = new Wallet();
         wallet.userId = userId;
         wallet.currency = currency;
-        wallet.currentBalance = BigDecimal.ZERO;
+        wallet.currentBalance = 0L;
         wallet.status = WalletStatus.ACTIVE;
         return wallet;
     }

--- a/src/main/java/com/payflow/infrastructure/security/JwtService.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtService.java
@@ -90,7 +90,7 @@ public class JwtService {
         }
     }
 
-     SecretKey getSignInKey() {
+     private SecretKey getSignInKey() {
         byte[] decodedKey = Base64.getDecoder().decode(jwtSecret);
         return Keys.hmacShaKeyFor(decodedKey);
     }

--- a/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
@@ -22,7 +22,6 @@ import org.springframework.security.authentication.AuthenticationProvider;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final UserRepository repository;
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final UserDetailsService userDetailsService;
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/payflow
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    username: ${DB_USER:dev}
+    password: ${DB_PASSWORD:dev}
     driver-class-name: org.postgresql.Driver
   data:
     redis:
@@ -19,3 +19,7 @@ logging:
   level:
     com.payflow: DEBUG
     org.hibernate.SQL: DEBUG
+
+app:
+  jwt:
+    secret: ${JWT_SECRET:bG9jYWwtZGV2LXNlY3JldC1rZXktbXVzdC1iZS1hdC1sZWFzdC0yNTYtYml0cy1sb25n}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: payflow
+  profiles:
+    active: local
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/db/migration/V7__fix_money_columns_bigint_cents.sql
+++ b/src/main/resources/db/migration/V7__fix_money_columns_bigint_cents.sql
@@ -1,0 +1,16 @@
+ALTER TABLE wallets
+ALTER COLUMN current_balance TYPE BIGINT
+USING (current_balance*100)::BIGINT;
+
+ALTER TABLE transactions
+ALTER COLUMN amount TYPE BIGINT
+USING (amount*100)::BIGINT;
+
+ALTER TABLE ledger_entries
+ALTER COLUMN amount TYPE BIGINT
+USING (amount*100)::BIGINT;
+
+ALTER TABLE ledger_entries
+ALTER COLUMN balance_after TYPE BIGINT
+USING (balance_after*100)::BIGINT;
+

--- a/src/main/resources/db/migration/V8__fix_ledger_timestamps.sql
+++ b/src/main/resources/db/migration/V8__fix_ledger_timestamps.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ledger_entries
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;

--- a/src/test/java/com/payflow/application/command/RegisterCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/RegisterCommandHandlerTest.java
@@ -1,6 +1,7 @@
 package com.payflow.application.command;
 
 import com.payflow.api.dto.response.AuthenticationResponse;
+import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.infrastructure.persistence.jpa.UserRepository;
@@ -13,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import org.springframework.security.authentication.BadCredentialsException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -78,7 +78,7 @@ class RegisterCommandHandlerTest {
         when(userRepository.existsByEmail(command.email())).thenReturn(true);
 
         assertThatThrownBy(() -> handler.handle(command))
-                .isInstanceOf(BadCredentialsException.class);
+                .isInstanceOf(EmailAlreadyRegisteredException.class);
 
         verify(userRepository, never()).save(any(User.class));
         verify(passwordEncoder, never()).encode(any());

--- a/src/test/java/com/payflow/application/query/wallet/WalletQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/wallet/WalletQueryHandlerTest.java
@@ -28,7 +28,7 @@ class WalletQueryHandlerTest {
     WalletQueryHandler walletQueryHandler;
 
     @Test
-    void handle_shouldThrowWhenWalletNotFound() {
+    void shouldThrowWhenWalletNotFound() {
         // Given
         when(walletRepository.findById(any())).thenReturn(Optional.empty());
 
@@ -39,7 +39,7 @@ class WalletQueryHandlerTest {
     }
 
     @Test
-    void handle_shouldThrowWhenWalletBelongsToDifferentUser() {
+    void shouldThrowWhenWalletBelongsToDifferentUser() {
         // Given
         Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("EUR"));
         when(walletRepository.findById(any())).thenReturn(Optional.of(wallet));

--- a/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
+++ b/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
@@ -2,7 +2,6 @@ package com.payflow.domain.model.wallet;
 
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.UUID;
 
@@ -12,12 +11,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class WalletTest {
 
     @Test
-    void create_shouldCreateWalletWithZeroBalance() {
+    void shouldCreateWalletWithZeroBalance() {
         //When
         Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
 
         //Then
-        assertThat(wallet.getCurrentBalance()).isEqualTo(BigDecimal.ZERO);
+        assertThat(wallet.getCurrentBalance()).isZero();
         assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ACTIVE);
         assertThat(wallet.getCurrency()).isEqualTo(Currency.getInstance("GBP"));
     }


### PR DESCRIPTION
## What
Resolves all four BLOCKERs identified in the Week 1 code review: wrong money type, missing TIMESTAMPTZ, wrong \`@Transactional\` import, and leaking a Spring security exception for duplicate email.

## Linked Issue
Closes #25

## Why
- \`BigDecimal\` for money violates the project rule (BIGINT cents); rounding errors in financial calculations are a real failure mode.
- \`TIMESTAMP\` without timezone loses UTC offset on reads — TIMESTAMPTZ is the correct type for \`Instant\` columns.
- \`jakarta.transaction.Transactional\` bypasses Spring's transaction infrastructure (no rollback rules, no AOP proxy integration).
- Throwing \`BadCredentialsException\` for duplicate email leaks an auth signal and maps to the wrong HTTP status.

## Changes
**Domain**
- Add \`EmailAlreadyRegisteredException\` (pure domain exception, no framework deps)
- \`Wallet.currentBalance\`: \`BigDecimal\` → \`Long\` (cents); initial value \`0L\`

**Application**
- \`RegisterCommandHandler\`: swap \`jakarta\` import for \`org.springframework.transaction.annotation.Transactional\`; throw \`EmailAlreadyRegisteredException\` instead of \`BadCredentialsException\`
- \`AuthQueryHandler\`: add \`@Transactional(readOnly = true)\` to \`handle()\`

**API**
- \`WalletResponse\`: \`balance\` field \`BigDecimal\` → \`Long\`
- \`GlobalExceptionHandler\`: handle \`EmailAlreadyRegisteredException\` → 409 CONFLICT

**Infrastructure**
- \`JwtService.getSignInKey()\`: make \`private\`
- \`SecurityConfig\`: remove unused \`UserRepository\` injection

**Persistence**
- \`V7\`: convert \`wallets.current_balance\`, \`transactions.amount\`, \`ledger_entries.amount\`, \`ledger_entries.balance_after\` to \`BIGINT\` cents
- \`V8\`: fix \`ledger_entries.created_at\` to \`TIMESTAMPTZ\`

**Config / Tests**
- \`application.yml\`: set \`spring.profiles.active=local\` default
- \`application-local.yml\`: add fallback defaults for DB credentials and JWT secret for local dev
- \`.gitignore\`: exclude \`application-local.yml\` from future commits
- Drop \`handle_\` prefix from test method names; use \`isZero()\` assertion instead of \`BigDecimal.ZERO\`

## Testing
- \`WalletTest\`: updated to assert \`isZero()\` on \`Long\` balance
- \`WalletQueryHandlerTest\`: method renames only, no logic change
- All existing unit tests (Mockito) continue to pass; no new integration tests required for these fixes

## Notes
\`application-local.yml\` is now gitignored going forward, but the current committed version remains tracked — run \`git rm --cached\` if full removal is needed later.