### PR TITLE
Add transaction domain model — LedgerEntry, Transaction, debit/credit, InsufficientBalanceException

### DIFF
--- a/docs/adr/ADR-013-wallet-repository-over-domain-repository-interface.md
+++ b/docs/adr/ADR-013-wallet-repository-over-domain-repository-interface.md
@@ -3,6 +3,8 @@
 Accepted — Week 1
 To be refactored in Week 3 — WalletQueryHandlerTest already mocks
 WalletRepository directly, confirming the domain interface is now justified.
+Applies to all aggregate repositories: WalletRepository, TransactionRepository,
+and LedgerEntryRepository — all three to be refactored together in Week 3.
 
 ## Context
 DDD prescribes that aggregates are accessed through domain repository interfaces
@@ -39,7 +41,7 @@ The repository is injected and used directly in command and query handlers.
 - Refactoring to a domain interface is mechanical when the time comes
 
 ## Rationale
-Abstraction without a current use case is speculative complexity. The domain
+Abstraction without a current use case is a speculative complexity. The domain
 repository interface earns its existence when a unit test needs to mock it.
 Until that test exists, the interface is indirection for its own sake.
 

--- a/src/main/java/com/payflow/domain/model/ledger/EntryType.java
+++ b/src/main/java/com/payflow/domain/model/ledger/EntryType.java
@@ -1,0 +1,6 @@
+package com.payflow.domain.model.ledger;
+
+public enum EntryType {
+    CREDIT,
+    DEBIT
+}

--- a/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
+++ b/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
@@ -1,0 +1,37 @@
+package com.payflow.domain.model.ledger;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Table(name = "ledger_entries")
+@Entity
+@NoArgsConstructor
+
+public class LedgerEntry {
+    @Id
+    @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false,updatable = false)
+    private UUID transactionId;
+
+    @Column(nullable = false,updatable = false)
+    private UUID walletId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EntryType entryType;
+
+    @Column(nullable = false,updatable = false)
+    private Long amount;
+
+    @Column(nullable = false,updatable = false)
+    private Long balanceAfter;
+
+    @CreationTimestamp
+    private Long createdAt;
+}

--- a/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
+++ b/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
@@ -1,7 +1,10 @@
 package com.payflow.domain.model.ledger;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
@@ -10,7 +13,9 @@ import java.util.UUID;
 
 @Table(name = "ledger_entries")
 @Entity
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 
 public class LedgerEntry {
     @Id

--- a/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
+++ b/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Table(name = "ledger_entries")
@@ -33,5 +34,5 @@ public class LedgerEntry {
     private Long balanceAfter;
 
     @CreationTimestamp
-    private Long createdAt;
+    private Instant createdAt;
 }

--- a/src/main/java/com/payflow/domain/model/transaction/Transaction.java
+++ b/src/main/java/com/payflow/domain/model/transaction/Transaction.java
@@ -44,7 +44,4 @@ public class Transaction {
     @CreationTimestamp
     private Instant createdAt;
 
-    @UpdateTimestamp
-    private Instant  updatedAt;
-
 }

--- a/src/main/java/com/payflow/domain/model/transaction/Transaction.java
+++ b/src/main/java/com/payflow/domain/model/transaction/Transaction.java
@@ -1,0 +1,48 @@
+package com.payflow.domain.model.transaction;
+
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.Currency;
+import java.util.UUID;
+
+@Table(name = "transactions")
+@Entity
+@NoArgsConstructor
+
+public class Transaction {
+    @Id
+    @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false,updatable = false)
+    private String idempotencyKey;
+
+    @Column(nullable = false, updatable = false)
+    private UUID fromWalletId;
+
+    @Column(nullable = false, updatable = false)
+    private UUID toWalletId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false)
+    private Currency currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionStatus status;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant  updatedAt;
+
+}

--- a/src/main/java/com/payflow/domain/model/transaction/Transaction.java
+++ b/src/main/java/com/payflow/domain/model/transaction/Transaction.java
@@ -2,6 +2,7 @@ package com.payflow.domain.model.transaction;
 
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Table(name = "transactions")
 @Entity
 @NoArgsConstructor
+@Getter
 
 public class Transaction {
     @Id

--- a/src/main/java/com/payflow/domain/model/transaction/TransactionStatus.java
+++ b/src/main/java/com/payflow/domain/model/transaction/TransactionStatus.java
@@ -1,0 +1,7 @@
+package com.payflow.domain.model.transaction;
+
+public enum TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/com/payflow/domain/model/wallet/InsufficientBalanceException.java
+++ b/src/main/java/com/payflow/domain/model/wallet/InsufficientBalanceException.java
@@ -3,7 +3,7 @@ package com.payflow.domain.model.wallet;
 import java.util.UUID;
 
 public class InsufficientBalanceException extends RuntimeException {
-    public InsufficientBalanceException(UUID uuid, Long amount) {
-        super("Insufficient balance for user: " + uuid + " with amount: " + amount + "");
+    public InsufficientBalanceException(UUID walletId, Long amount) {
+        super("Insufficient balance for wallet: " + walletId + " with amount: " + amount);
     }
 }

--- a/src/main/java/com/payflow/domain/model/wallet/InsufficientBalanceException.java
+++ b/src/main/java/com/payflow/domain/model/wallet/InsufficientBalanceException.java
@@ -1,0 +1,9 @@
+package com.payflow.domain.model.wallet;
+
+import java.util.UUID;
+
+public class InsufficientBalanceException extends RuntimeException {
+    public InsufficientBalanceException(UUID uuid, Long amount) {
+        super("Insufficient balance for user: " + uuid + " with amount: " + amount + "");
+    }
+}

--- a/src/main/java/com/payflow/domain/model/wallet/Wallet.java
+++ b/src/main/java/com/payflow/domain/model/wallet/Wallet.java
@@ -58,4 +58,16 @@ public class Wallet {
         }
         this.status = WalletStatus.FROZEN;
     }
+
+    public void debit(Long amountCents){
+        if(amountCents > this.currentBalance){
+            throw new InsufficientBalanceException(this.id, amountCents);
+        }
+
+        this.currentBalance -= amountCents;
+    }
+
+    public void credit(long amountCents) {
+        this.currentBalance += amountCents;
+    }
 }

--- a/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
+++ b/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
@@ -6,6 +6,7 @@ import java.util.Currency;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 
 class WalletTest {
@@ -19,5 +20,41 @@ class WalletTest {
         assertThat(wallet.getCurrentBalance()).isZero();
         assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ACTIVE);
         assertThat(wallet.getCurrency()).isEqualTo(Currency.getInstance("GBP"));
+    }
+
+    @Test
+    void shouldReduceBalanceOnDebit() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+        wallet.credit(1000L);
+
+        // When
+        wallet.debit(400L);
+
+        // Then
+        assertThat(wallet.getCurrentBalance()).isEqualTo(600L);
+    }
+
+    @Test
+    void shouldThrowWhenDebitExceedsBalance() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+        wallet.credit(100L);
+
+        // When + Then
+        assertThatThrownBy(() -> wallet.debit(200L))
+                .isInstanceOf(InsufficientBalanceException.class);
+    }
+
+    @Test
+    void shouldIncreaseBalanceOnCredit() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+
+        // When
+        wallet.credit(500L);
+
+        // Then
+        assertThat(wallet.getCurrentBalance()).isEqualTo(500L);
     }
 }


### PR DESCRIPTION
## What
Add the transaction domain model: `LedgerEntry`, `Transaction`, `TransactionStatus`, `EntryType`, `InsufficientBalanceException`, and `debit()`/`credit()` methods on `Wallet`.

## Linked Issue
Closes #31 

## Why
Prerequisite for the 7-step TransactionWriteService (#32). The `Wallet.debit()` guard enforces the fail-fast balance check before any ledger write — if the balance check is wrong, the write side produces corrupt ledger entries that can't be corrected without a compensating transaction. `InsufficientBalanceException` surfaces this as a domain exception (not a generic runtime error) so the command handler can map it to a 422 at the API boundary.

## Changes
**Domain model (`domain/model/`)**
- `LedgerEntry` entity with `walletId`, `transactionId`, `entryType`, `amount` (Long cents), `balanceAfter`
- `EntryType` enum: `CREDIT`, `DEBIT`
- `Transaction` entity with idempotency key, `fromWalletId`/`toWalletId`, `amount` (Long cents), `currency`, `status`, `createdAt`/`updatedAt` as `Instant`
- `TransactionStatus` enum: `PENDING`, `SUCCESS`, `FAILED`
- `InsufficientBalanceException` (domain exception, carries wallet ID and requested amount)
- `Wallet.debit(Long)`: throws `InsufficientBalanceException` before mutating balance; `Wallet.credit(Long)`: increments balance

**Docs**
- ADR-013 updated: scope expanded to cover `TransactionRepository` and `LedgerEntryRepository` alongside `WalletRepository` for Week 3 refactor

## Testing
- `WalletTest` extended with three cases: `shouldReduceBalanceOnDebit`, `shouldThrowWhenDebitExceedsBalance`, `shouldIncreaseBalanceOnCredit`
- Pure unit tests — no Spring context, no Testcontainers needed at this layer