### PR TITLE
Map transaction exceptions to HTTP responses in GlobalExceptionHandler

### DIFF
--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.payflow.api.exception;
 
 import com.payflow.api.dto.response.ErrorResponse;
+import com.payflow.domain.model.transaction.CurrencyMismatchException;
 import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
+import com.payflow.domain.model.wallet.InsufficientBalanceException;
 import com.payflow.domain.model.wallet.WalletAlreadyExistsException;
 import com.payflow.domain.model.wallet.WalletNotFoundException;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
@@ -31,6 +35,7 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleGeneric(Exception ex) {
         return new ErrorResponse("INTERNAL_ERROR", "An unexpected error occurred");
     }
+
     @ExceptionHandler(EmailAlreadyRegisteredException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handeDuplicateEmail(EmailAlreadyRegisteredException ex) {
@@ -47,5 +52,31 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handleIllegalState(IllegalStateException ex) {
         return new ErrorResponse("INVALID_WALLET_STATE", ex.getMessage());
+    }
+
+    @ExceptionHandler(InsufficientBalanceException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
+    public ErrorResponse handleInsufficientBalance(InsufficientBalanceException ex) {
+        return new ErrorResponse("INSUFFICIENT_BALANCE", ex.getMessage());
+    }
+
+
+    @ExceptionHandler(CurrencyMismatchException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
+    public ErrorResponse handleCurrencyMismatch(CurrencyMismatchException ex) {
+        return new ErrorResponse("CURRENCY_MISMATCH", ex.getMessage());
+    }
+
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleDataIntegrity(DataIntegrityViolationException ex) {
+        return new ErrorResponse("CONSTRAINT_VIOLATION", "Request violates a data constraint");
+    }
+
+    @ExceptionHandler(CannotAcquireLockException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ErrorResponse handleLockTimeout(CannotAcquireLockException ex) {
+        return new ErrorResponse("LOCK_TIMEOUT", "Service is under high load, please retry");
     }
 }

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -60,14 +60,11 @@ public class GlobalExceptionHandler {
         return new ErrorResponse("INSUFFICIENT_BALANCE", ex.getMessage());
     }
 
-
     @ExceptionHandler(CurrencyMismatchException.class)
     @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
     public ErrorResponse handleCurrencyMismatch(CurrencyMismatchException ex) {
         return new ErrorResponse("CURRENCY_MISMATCH", ex.getMessage());
     }
-
-
     @ExceptionHandler(DataIntegrityViolationException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handleDataIntegrity(DataIntegrityViolationException ex) {


### PR DESCRIPTION
## What
Adds four new exception handlers to `GlobalExceptionHandler` that translate transaction-domain failures into well-typed HTTP error responses.

## Linked Issue
Closes #33

## Why
Without explicit mappings, `InsufficientBalanceException` and `CurrencyMismatchException` would fall through to the generic 500 handler, giving clients no actionable signal. `CannotAcquireLockException` (thrown when SERIALIZABLE transactions contend) needs a 503 so callers know to retry rather than treat it as a hard failure. `DataIntegrityViolationException` is mapped to 409 to surface constraint violations cleanly.

## Changes
- `api/exception/GlobalExceptionHandler` — added handlers:
  - `InsufficientBalanceException` → 422 with `INSUFFICIENT_BALANCE`
  - `CurrencyMismatchException` → 422 with `CURRENCY_MISMATCH`
  - `DataIntegrityViolationException` → 409 with `CONSTRAINT_VIOLATION`
  - `CannotAcquireLockException` → 503 with `LOCK_TIMEOUT`

## Testing
No new test classes — exception handler mappings are exercised via the existing command handler integration paths. Unit tests for the transaction command handlers are tracked in #37.

## Notes
`CannotAcquireLockException` is the Spring translation of a PostgreSQL serialization failure under SERIALIZABLE isolation. Mapping it to 503 (instead of 409) signals a transient condition and keeps retry semantics clear for clients.