### PR TITLE
Add transaction endpoints with deposit, withdraw, transfer, and history

### DIFF
--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -7,7 +7,6 @@ import com.payflow.application.command.TransferCommandHandler;
 import com.payflow.application.command.WithdrawCommandHandler;
 import com.payflow.application.query.TransactionQueryHandler;
 import com.payflow.domain.model.user.User;
-import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -42,7 +42,7 @@ public class TransactionController {
         return transactionQueryHandler.handle(new TransactionQueryHandler.GetTransactionQuery(id, user.getId()));
     }
 
-    @PostMapping("/transactions/deposit")
+    @PostMapping("/deposit")
     public ResponseEntity<TransactionResponse> deposit(
             @RequestBody @Valid TransactionRequest.DepositRequest request,
             @AuthenticationPrincipal User user)

--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -1,0 +1,88 @@
+package com.payflow.api.controller;
+
+import com.payflow.api.dto.request.TransactionRequest;
+import com.payflow.api.dto.response.TransactionResponse;
+import com.payflow.application.command.DepositCommandHandler;
+import com.payflow.application.command.TransferCommandHandler;
+import com.payflow.application.command.WithdrawCommandHandler;
+import com.payflow.application.query.TransactionQueryHandler;
+import com.payflow.domain.model.user.User;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/transactions")
+public class TransactionController {
+    private final TransactionQueryHandler transactionQueryHandler;
+    private final DepositCommandHandler depositCommandHandler;
+    private final WithdrawCommandHandler withdrawCommandHandler;
+    private final TransferCommandHandler transferCommandHandler;
+
+    @GetMapping
+    public Page<TransactionResponse> getTransactions(Pageable pageable,
+                                                     @AuthenticationPrincipal User user) {
+        return transactionQueryHandler
+                .handle(new TransactionQueryHandler
+                        .GetTransactionsQuery(user.getId(), pageable));
+    }
+
+    @GetMapping("/{id}")
+    public TransactionResponse getTransaction(@PathVariable UUID id, @AuthenticationPrincipal User user)
+    {
+        return transactionQueryHandler.handle(new TransactionQueryHandler.GetTransactionQuery(id, user.getId()));
+    }
+
+    @PostMapping("/transactions/deposit")
+    public ResponseEntity<TransactionResponse> deposit(
+            @RequestBody @Valid TransactionRequest.DepositRequest request,
+            @AuthenticationPrincipal User user)
+    {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(TransactionResponse.from(depositCommandHandler.handle(
+                        new DepositCommandHandler.Command(
+                                request.idempotencyKey().toString(),
+                                request.toWalletId(),
+                                user.getId(),
+                                request.amount()
+                        )
+                        )
+                ));
+    }
+    @PostMapping("/withdraw")
+    public ResponseEntity<TransactionResponse> withdraw(
+            @RequestBody @Valid TransactionRequest.WithdrawRequest request,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(TransactionResponse.from(withdrawCommandHandler.handle(
+                        new WithdrawCommandHandler.Command(
+                                request.idempotencyKey().toString(),
+                                request.fromWalletId(),
+                                user.getId(),
+                                request.amount()
+                        ))));
+    }
+    @PostMapping("/transfer")
+    public ResponseEntity<TransactionResponse> transfer(
+            @RequestBody @Valid TransactionRequest.TransferRequest request,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(TransactionResponse.from(transferCommandHandler.handle(
+                        new TransferCommandHandler.Command(
+                                request.idempotencyKey().toString(),
+                                request.fromWalletId(),
+                                request.toWalletId(),
+                                user.getId(),
+                                request.amount()
+                        ))));
+    }
+}

--- a/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
+++ b/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
@@ -6,14 +6,12 @@ public class TransactionRequest {
     public record DepositRequest(
             UUID toWalletId,
             Long amount,          // cents
-            String currency,
             UUID idempotencyKey
     ) {}
 
     public  record WithdrawRequest(
             UUID fromWalletId,
             Long amount,          // cents
-            String currency,
             UUID idempotencyKey
     ) {}
 
@@ -21,7 +19,6 @@ public class TransactionRequest {
             UUID fromWalletId,
             UUID toWalletId,
             Long amount,          // cents
-            String currency,
             UUID idempotencyKey
     ) {}
 }

--- a/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
+++ b/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
@@ -1,27 +1,29 @@
 package com.payflow.api.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.util.UUID;
 
 public class TransactionRequest {
     public record DepositRequest(
             UUID toWalletId,
-            Long amount,          // cents
+            @NotNull @Positive Long amount,          // cents
             String currency,
-            UUID idempotencyKey
+            @NotNull UUID idempotencyKey
     ) {}
 
     public  record WithdrawRequest(
             UUID fromWalletId,
-            Long amount,          // cents
+            @NotNull @Positive Long amount,          // cents
             String currency,
-            UUID idempotencyKey
+            @NotNull UUID idempotencyKey
     ) {}
 
     public record TransferRequest(
             UUID fromWalletId,
             UUID toWalletId,
-            Long amount,          // cents
+            @NotNull @Positive Long amount,          // cents
             String currency,
-            UUID idempotencyKey
+            @NotNull UUID idempotencyKey
     ) {}
 }

--- a/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
+++ b/src/main/java/com/payflow/api/dto/request/TransactionRequest.java
@@ -1,0 +1,27 @@
+package com.payflow.api.dto.request;
+
+import java.util.UUID;
+
+public class TransactionRequest {
+    public record DepositRequest(
+            UUID toWalletId,
+            Long amount,          // cents
+            String currency,
+            UUID idempotencyKey
+    ) {}
+
+    public  record WithdrawRequest(
+            UUID fromWalletId,
+            Long amount,          // cents
+            String currency,
+            UUID idempotencyKey
+    ) {}
+
+    public record TransferRequest(
+            UUID fromWalletId,
+            UUID toWalletId,
+            Long amount,          // cents
+            String currency,
+            UUID idempotencyKey
+    ) {}
+}

--- a/src/main/java/com/payflow/api/dto/response/TransactionResponse.java
+++ b/src/main/java/com/payflow/api/dto/response/TransactionResponse.java
@@ -1,0 +1,33 @@
+package com.payflow.api.dto.response;
+
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionStatus;
+import com.payflow.domain.model.transaction.TransactionType;
+
+import java.time.Instant;
+import java.util.Currency;
+import java.util.UUID;
+
+public record TransactionResponse(
+        UUID id,
+        UUID fromWalletId,
+        TransactionType type,
+        long amount,
+        Currency currency,
+        TransactionStatus status,
+        UUID toWalletId,
+        Instant createdAt
+) {
+    public static TransactionResponse from(Transaction projection) {
+        return new TransactionResponse(
+                projection.getId(),
+                projection.getFromWalletId(),
+                projection.getType(),
+                projection.getAmount(),
+                projection.getCurrency(),
+                projection.getStatus(),
+                projection.getToWalletId(),
+                projection.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.payflow.api.exception;
 
 import com.payflow.api.dto.response.ErrorResponse;
 import com.payflow.domain.model.transaction.CurrencyMismatchException;
+import com.payflow.domain.model.transaction.InvalidWalletOperationException;
 import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.wallet.InsufficientBalanceException;
 import com.payflow.domain.model.wallet.WalletAlreadyExistsException;
@@ -75,5 +76,11 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     public ErrorResponse handleLockTimeout(CannotAcquireLockException ex) {
         return new ErrorResponse("LOCK_TIMEOUT", "Service is under high load, please retry");
+    }
+
+    @ExceptionHandler(InvalidWalletOperationException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
+    public ErrorResponse handleInvalidWalletOperation(InvalidWalletOperationException ex) {
+        return new ErrorResponse("INVALID_WALLET_OPERATION", ex.getMessage());
     }
 }

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.payflow.api.exception;
 import com.payflow.api.dto.response.ErrorResponse;
 import com.payflow.domain.model.transaction.CurrencyMismatchException;
 import com.payflow.domain.model.transaction.InvalidWalletOperationException;
+import com.payflow.domain.model.transaction.TransactionNotFoundException;
 import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.wallet.InsufficientBalanceException;
 import com.payflow.domain.model.wallet.WalletAlreadyExistsException;
@@ -82,5 +83,10 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
     public ErrorResponse handleInvalidWalletOperation(InvalidWalletOperationException ex) {
         return new ErrorResponse("INVALID_WALLET_OPERATION", ex.getMessage());
+    }
+    @ExceptionHandler(TransactionNotFoundException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleTransactionNotFound(TransactionNotFoundException ex) {
+        return new ErrorResponse("TRANSACTION_NOT_FOUND", ex.getMessage());
     }
 }

--- a/src/main/java/com/payflow/application/command/DepositCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/DepositCommandHandler.java
@@ -53,7 +53,8 @@ public class DepositCommandHandler {
                 null,
                 command.walletId(),
                 command.amountCents(),
-                wallet.getCurrency()
+                wallet.getCurrency(),
+                command.requestingUserId()
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 

--- a/src/main/java/com/payflow/application/command/TransferCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/TransferCommandHandler.java
@@ -4,6 +4,7 @@ import com.payflow.application.service.IdempotencyService;
 import com.payflow.application.service.LedgerService;
 import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.transaction.CurrencyMismatchException;
+import com.payflow.domain.model.transaction.InvalidWalletOperationException;
 import com.payflow.domain.model.transaction.Transaction;
 import com.payflow.domain.model.transaction.TransactionType;
 import com.payflow.domain.model.wallet.Wallet;
@@ -46,7 +47,7 @@ public class TransferCommandHandler {
     private Transaction processNew(Command command) {
         // STEP 2: Validate — no self-transfer
         if (command.sourceWalletId().equals(command.destinationWalletId())) {
-            throw new IllegalArgumentException("Cannot transfer to the same wallet");
+            throw new InvalidWalletOperationException(command.sourceWalletId());
         }
 
         // STEP 3: Load both wallets — only a source needs ownership check

--- a/src/main/java/com/payflow/application/command/TransferCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/TransferCommandHandler.java
@@ -65,7 +65,8 @@ public class TransferCommandHandler {
                 command.sourceWalletId(),
                 command.destinationWalletId(),
                 command.amountCents(),
-                sourceWallet.getCurrency()
+                sourceWallet.getCurrency(),
+                command.requestingUserId()
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 

--- a/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
@@ -55,7 +55,8 @@ public class WithdrawCommandHandler {
                 command.walletId(),
                 null,
                 command.amountCents(),
-                wallet.getCurrency()
+                wallet.getCurrency(),
+                command.requestingUserId()
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 

--- a/src/main/java/com/payflow/application/query/TransactionQueryHandler.java
+++ b/src/main/java/com/payflow/application/query/TransactionQueryHandler.java
@@ -1,0 +1,37 @@
+package com.payflow.application.query;
+
+import com.payflow.api.dto.response.TransactionResponse;
+import com.payflow.domain.model.transaction.TransactionNotFoundException;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionQueryHandler {
+
+    public record GetTransactionsQuery(UUID userId, Pageable pageable) {}
+    public record GetTransactionQuery(UUID transactionId, UUID userId) {}
+
+    private final TransactionRepository repository;
+
+    @Transactional(readOnly = true)
+    public Page<TransactionResponse> handle(GetTransactionsQuery query) {
+        return repository.findAllByUserIdOrderByCreatedAtDesc(query.userId(), query.pageable())
+                .map(TransactionResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public TransactionResponse handle(GetTransactionQuery query) {
+        return TransactionResponse.from(
+                repository.findByIdAndUserId(query.transactionId(), query.userId())
+                .orElseThrow(() ->
+                        new TransactionNotFoundException(query.transactionId())));
+    }
+
+}

--- a/src/main/java/com/payflow/domain/model/transaction/InvalidWalletOperationException.java
+++ b/src/main/java/com/payflow/domain/model/transaction/InvalidWalletOperationException.java
@@ -1,0 +1,9 @@
+package com.payflow.domain.model.transaction;
+
+import java.util.UUID;
+
+public class InvalidWalletOperationException extends RuntimeException {
+    public InvalidWalletOperationException(UUID walletId) {
+        super("Invalid wallet operation for wallet: " + walletId);
+    }
+}

--- a/src/main/java/com/payflow/domain/model/transaction/Transaction.java
+++ b/src/main/java/com/payflow/domain/model/transaction/Transaction.java
@@ -46,8 +46,11 @@ public class Transaction {
     @CreationTimestamp
     private Instant createdAt;
 
-    @Column(nullable = true)
+    @Column
     private Instant completedAt;
+
+    @Column
+    private UUID userId;
 
     public void complete() {
         this.status = TransactionStatus.SUCCESS;

--- a/src/main/java/com/payflow/domain/model/transaction/Transaction.java
+++ b/src/main/java/com/payflow/domain/model/transaction/Transaction.java
@@ -57,7 +57,7 @@ public class Transaction {
         this.completedAt = Instant.now();
     }
 
-    public static Transaction create(String idempotencyKey, TransactionType type, UUID fromWalletId, UUID toWalletId, Long amount, Currency currency) {
+    public static Transaction create(String idempotencyKey, TransactionType type, UUID fromWalletId, UUID toWalletId, Long amount, Currency currency, UUID userId) {
         Transaction transaction = new Transaction();
         transaction.idempotencyKey = idempotencyKey;
         transaction.type = type;
@@ -66,6 +66,7 @@ public class Transaction {
         transaction.amount = amount;
         transaction.currency = currency;
         transaction.status = TransactionStatus.PENDING;
+        transaction.userId = userId;
         return transaction;
     }
 }

--- a/src/main/java/com/payflow/domain/model/transaction/TransactionNotFoundException.java
+++ b/src/main/java/com/payflow/domain/model/transaction/TransactionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.payflow.domain.model.transaction;
+
+import java.util.UUID;
+
+public class TransactionNotFoundException extends RuntimeException {
+    public TransactionNotFoundException(UUID transactionId) {
+        super("Transaction not found: " + transactionId);
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionRepository.java
@@ -1,6 +1,8 @@
 package com.payflow.infrastructure.persistence.jpa;
 
 import com.payflow.domain.model.transaction.Transaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,7 @@ import java.util.UUID;
 
 public interface TransactionRepository extends JpaRepository<Transaction,UUID > {
     Optional<Transaction> findByIdempotencyKey(String idempotencyKey);
+
+    Page<Transaction> findAllByUserIdOrderByCreatedAtDesc(UUID uuid, Pageable pageable);
+    Optional<Transaction> findByIdAndUserId(UUID uuid, UUID userId);
 }

--- a/src/main/resources/db/migration/V12__add_userId_to_transactions.sql
+++ b/src/main/resources/db/migration/V12__add_userId_to_transactions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transactions
+    ADD COLUMN user_id UUID REFERENCES users(id);

--- a/src/main/resources/db/migration/V13__create_user_id_index_transactions.sql
+++ b/src/main/resources/db/migration/V13__create_user_id_index_transactions.sql
@@ -1,0 +1,3 @@
+
+CREATE INDEX idx_transactions_user_id_created_at
+    ON transactions (user_id, created_at DESC);


### PR DESCRIPTION
## What
Adds REST endpoints for deposit, withdraw, transfer, and transaction history (list + single), backed by command/query handlers and a new `user_id` column on the transactions table.

## Linked Issue
Closes #36

## Why
Completes the core payment flow — without these endpoints the funded wallet has no way to move money. Handlers use the Outbox pattern (write to `outbox_events` in the same transaction) and idempotency keys to prevent duplicate processing on retry.

## Changes
**API layer**
- `TransactionController` — deposit (`POST /transactions/deposit`), withdraw (`POST /withdraw`), transfer (`POST /transfer`), list (`GET /transactions`), single (`GET /transactions/{id}`)
- `TransactionRequest` — typed request records (deposit/withdraw/transfer) with idempotency key
- `TransactionResponse` — read model record with static `from(Transaction)` factory

**Application layer**
- `TransactionQueryHandler` — `GetTransactionsQuery` (paginated, filtered by `userId`) and `GetTransactionQuery` (single, ownership-checked)

**Domain**
- `TransactionNotFoundException` — custom 404 exception for missing/unauthorized transaction lookup
- `InvalidWalletOperationException` — custom exception for invalid wallet state transitions

**Persistence**
- `V12` migration — adds `user_id UUID REFERENCES users(id)` to `transactions`
- `TransactionRepository` — `findAllByUserIdOrderByCreatedAtDesc` and `findByIdAndUserId` for ownership-scoped queries

## Testing
- Existing unit tests cover `DepositCommandHandler`, `WithdrawCommandHandler`, `TransferCommandHandler`
- `PayflowApplicationTests.contextLoads` — full Spring context with Testcontainers PostgreSQL

## Notes
- Deposit URL is `POST /transactions/transactions/deposit` due to a double-path segment — follow-up needed to fix the mapping to `POST /transactions/deposit`
- `TransactionRequest` fields have no `@NotNull`/`@Valid` constraints yet — validation is currently enforced only by DB not-null constraints