### PR TITLE
Add unit test suite for transaction command handlers and supporting services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,7 +51,7 @@ Self-invocation bypasses the AOP proxy — `@Transactional` silently does nothin
 ## Data Rules (quick ref)
 - Money: `BIGINT` cents — never `DECIMAL`, never `FLOAT`
 - PKs: `UUID` generated at domain layer, not by the DB
-- Balance: always derived (`SUM(ledger_entries)`), never a mutable column
+- Balance: cached `BIGINT` column on `wallets` for O(1) reads — ledger entries are the audit trail and source of truth; ledger is always written before the cached balance is updated; nightly reconciliation detects drift
 - Schema: Flyway only — `ddl-auto: validate` everywhere
 
 ## Hard Rules (never do these)

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ build/
 
 .env*
 /src/main/resources/application-local.yml
-.claude
+.claude/

--- a/src/main/java/com/payflow/application/command/DepositCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/DepositCommandHandler.java
@@ -26,7 +26,13 @@ public class DepositCommandHandler {
             UUID walletId,
             UUID requestingUserId,
             long amountCents
-    ) {}
+    ) {
+        public Command {
+            if (amountCents <= 0) {
+                throw new IllegalArgumentException("Deposit amount must be positive, got: " + amountCents);
+            }
+        }
+    }
 
     private final IdempotencyService idempotencyService;
     private final TransactionRepository transactionRepository;

--- a/src/main/java/com/payflow/application/command/TransferCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/TransferCommandHandler.java
@@ -54,10 +54,10 @@ public class TransferCommandHandler {
 
         // STEP 3: Load both wallets — only source needs ownership check
         Wallet sourceWallet = walletService.getActiveById(command.sourceWalletId(), command.requestingUserId());
-        Wallet destionationWallet = walletRepository.findByIdAndStatus(command.destinationWalletId(), WalletStatus.ACTIVE)
+        Wallet destinationWallet = walletRepository.findByIdAndStatus(command.destinationWalletId(), WalletStatus.ACTIVE)
                 .orElseThrow(() -> new WalletNotFoundException(command.destinationWalletId()));
-        if (!sourceWallet.getCurrency().equals(destionationWallet.getCurrency())) {
-            throw new CurrencyMismatchException(sourceWallet.getCurrency(), destionationWallet.getCurrency());
+        if (!sourceWallet.getCurrency().equals(destinationWallet.getCurrency())) {
+            throw new CurrencyMismatchException(sourceWallet.getCurrency(), destinationWallet.getCurrency());
         }
 
 
@@ -79,9 +79,9 @@ public class TransferCommandHandler {
         walletRepository.save(sourceWallet);
 
         // STEP 6: Credit destination
-        ledgerService.createCreditEntry(tx, destionationWallet, command.amountCents());
-        destionationWallet.credit(command.amountCents());
-        walletRepository.save(destionationWallet);
+        ledgerService.createCreditEntry(tx, destinationWallet, command.amountCents());
+        destinationWallet.credit(command.amountCents());
+        walletRepository.save(destinationWallet);
 
         // STEP 7: Mark complete and persist
         tx.complete();

--- a/src/main/java/com/payflow/application/command/TransferCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/TransferCommandHandler.java
@@ -8,6 +8,8 @@ import com.payflow.domain.model.transaction.InvalidWalletOperationException;
 import com.payflow.domain.model.transaction.Transaction;
 import com.payflow.domain.model.transaction.TransactionType;
 import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.model.wallet.WalletStatus;
 import com.payflow.infrastructure.kafka.TransactionOutboxWriter;
 import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
 import com.payflow.infrastructure.persistence.jpa.WalletRepository;
@@ -50,9 +52,10 @@ public class TransferCommandHandler {
             throw new InvalidWalletOperationException(command.sourceWalletId());
         }
 
-        // STEP 3: Load both wallets — only a source needs ownership check
+        // STEP 3: Load both wallets — only source needs ownership check
         Wallet sourceWallet = walletService.getActiveById(command.sourceWalletId(), command.requestingUserId());
-        Wallet destionationWallet = walletService.getActiveById(command.destinationWalletId(), command.requestingUserId());
+        Wallet destionationWallet = walletRepository.findByIdAndStatus(command.destinationWalletId(), WalletStatus.ACTIVE)
+                .orElseThrow(() -> new WalletNotFoundException(command.destinationWalletId()));
         if (!sourceWallet.getCurrency().equals(destionationWallet.getCurrency())) {
             throw new CurrencyMismatchException(sourceWallet.getCurrency(), destionationWallet.getCurrency());
         }
@@ -70,10 +73,10 @@ public class TransferCommandHandler {
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 
-        // STEP 5: Debit source first — throws InsufficientBalanceException if needed
+        // STEP 5: Debit source — ledger first, then mutate cached balance
+        ledgerService.createDebitEntry(tx, sourceWallet, command.amountCents());
         sourceWallet.debit(command.amountCents());
         walletRepository.save(sourceWallet);
-        ledgerService.createDebitEntry(tx, sourceWallet, command.amountCents());
 
         // STEP 6: Credit destination
         ledgerService.createCreditEntry(tx, destionationWallet, command.amountCents());

--- a/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
@@ -60,12 +60,12 @@ public class WithdrawCommandHandler {
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 
-        // STEP 5: debit first - checks balance AND updates currentBalance
+        // STEP 5: Ledger entry first — balanceAfter calculated before cache is mutated
+        ledgerService.createDebitEntry(tx, wallet, command.amountCents());
+
+        // STEP 6: Debit cached balance after ledger is written
         wallet.debit(command.amountCents());
         walletRepository.save(wallet);
-
-        // STEP 4: Ledger entry after = balanceAfter is now correct
-        ledgerService.createDebitEntry(tx, wallet, command.amountCents());
 
         // STEP 6: Mark complete and persist
         tx.complete();

--- a/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/WithdrawCommandHandler.java
@@ -60,10 +60,10 @@ public class WithdrawCommandHandler {
         );
         tx = idempotencyService.deduplicateOrSave(tx);
 
-        // STEP 5: Ledger entry first — balanceAfter calculated before cache is mutated
+        // STEP 4: Ledger entry first — balanceAfter calculated before cache is mutated
         ledgerService.createDebitEntry(tx, wallet, command.amountCents());
 
-        // STEP 6: Debit cached balance after ledger is written
+        // STEP 5: Debit cached balance after the ledger is written
         wallet.debit(command.amountCents());
         walletRepository.save(wallet);
 

--- a/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
+++ b/src/main/java/com/payflow/domain/model/ledger/LedgerEntry.java
@@ -3,8 +3,8 @@ package com.payflow.domain.model.ledger;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
@@ -14,6 +14,7 @@ import java.util.UUID;
 @Table(name = "ledger_entries")
 @Entity
 @Builder
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletRepository.java
@@ -15,5 +15,6 @@ public interface WalletRepository extends JpaRepository<Wallet, UUID> {
     List<Wallet> findAllByUserId(UUID userId);
 
     Optional<Wallet> findByIdAndUserIdAndStatus(UUID id, UUID userId, WalletStatus status);
+    Optional<Wallet> findByIdAndStatus(UUID id, WalletStatus status);
 
 }

--- a/src/test/java/com/payflow/application/command/DepositCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/DepositCommandHandlerTest.java
@@ -1,0 +1,118 @@
+package com.payflow.application.command;
+
+import com.payflow.application.service.IdempotencyService;
+import com.payflow.application.service.LedgerService;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionStatus;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.kafka.TransactionOutboxWriter;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DepositCommandHandlerTest {
+    @Mock
+    private WalletService walletService;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private LedgerService ledgerService;
+
+    @Mock
+    private TransactionOutboxWriter eventPublisher;
+
+    @InjectMocks
+    private DepositCommandHandler handler;
+
+    private static final UUID USER_ID   = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final Currency EUR   = Currency.getInstance("EUR");
+
+    private DepositCommandHandler.Command command(long amountCents) {
+        return new DepositCommandHandler.Command("idem-key-1", WALLET_ID, USER_ID, amountCents);
+    }
+    private Wallet activeWallet(long amountCents) {
+       Wallet wallet = Wallet.create(USER_ID,EUR);
+       wallet.credit(amountCents);
+       return wallet;
+    }
+
+    @Test
+    void shouldDepositCreditWalletAndReturnCompletedTransaction() {
+        // Given
+        Wallet wallet = activeWallet(10_000L);
+
+        when(idempotencyService.findDuplicate("idem-key-1"))
+                .thenReturn(Optional.empty());
+        when(walletService.getActiveById(WALLET_ID, USER_ID))
+                .thenReturn(wallet);
+        when(idempotencyService.deduplicateOrSave(any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(transactionRepository.save(any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // When
+        Transaction result = handler.handle(command(3000L));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+        assertThat(result.getType()).isEqualTo(TransactionType.DEPOSIT);
+        assertThat(result.getToWalletId()).isEqualTo(WALLET_ID);
+        assertThat(result.getFromWalletId()).isNull();
+        assertThat(result.getAmount()).isEqualTo(3000L);
+        assertThat(wallet.getCurrentBalance()).isEqualTo(13_000L);
+        verify(ledgerService)
+                .createCreditEntry(any(Transaction.class), eq(wallet),
+                        eq(3000L));
+        verify(eventPublisher)
+                .publishTransactionCreated(any(Transaction.class));
+    }
+
+    @Test
+    void shouldThrowWhenAmountIsZeroOrNegative() {
+        assertThatThrownBy(() -> command(0L))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> command(-1L))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(walletService, idempotencyService, ledgerService, eventPublisher, transactionRepository);
+    }
+
+    @Test
+    void shouldReturnExistingTransactionOnDuplicateKey() {
+        // Given
+        Transaction existing = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+        existing.complete();
+
+        when(idempotencyService.findDuplicate("idem-key-1")).thenReturn(Optional.of(existing));
+
+        // When
+        Transaction result = handler.handle(command(5000L));
+
+        // Then
+        assertThat(result).isSameAs(existing);
+        verifyNoInteractions(walletService, ledgerService, eventPublisher, transactionRepository);
+    }
+}

--- a/src/test/java/com/payflow/application/command/TransferCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/TransferCommandHandlerTest.java
@@ -1,0 +1,170 @@
+package com.payflow.application.command;
+
+import com.payflow.application.service.IdempotencyService;
+import com.payflow.application.service.LedgerService;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.transaction.CurrencyMismatchException;
+import com.payflow.domain.model.transaction.InvalidWalletOperationException;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionStatus;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.model.wallet.WalletStatus;
+import com.payflow.infrastructure.kafka.TransactionOutboxWriter;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import com.payflow.infrastructure.persistence.jpa.WalletRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TransferCommandHandlerTest {
+
+    @Mock
+    private WalletService walletService;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private LedgerService ledgerService;
+
+    @Mock
+    private TransactionOutboxWriter eventPublisher;
+
+    @InjectMocks
+    private TransferCommandHandler handler;
+
+    private static final UUID USER_ID   = UUID.randomUUID();
+    private static final UUID SOURCE_ID = UUID.randomUUID();
+    private static final UUID DEST_ID   = UUID.randomUUID();
+    private static final Currency EUR   = Currency.getInstance("EUR");
+    private static final Currency GBP   = Currency.getInstance("GBP");
+
+    private TransferCommandHandler.Command command(UUID sourceId, UUID destId, long amountCents) {
+        return new TransferCommandHandler.Command("idem-key-1", sourceId, destId, USER_ID, amountCents);
+    }
+
+    private Wallet wallet(UUID userId, Currency currency, long balance) {
+        Wallet wallet = Wallet.create(userId, currency);
+        wallet.credit(balance);
+        return wallet;
+    }
+
+
+    @Test
+    void shouldTransferDebitSourceCreditDestinationAndReturnCompletedTransaction() {
+        // Given
+        Wallet source = wallet(USER_ID, EUR, 10_000L);
+        Wallet dest   = wallet(UUID.randomUUID(), EUR, 5_000L);
+
+        when(idempotencyService.findDuplicate("idem-key-1")).thenReturn(Optional.empty());
+        when(walletService.getActiveById(SOURCE_ID, USER_ID)).thenReturn(source);
+        when(walletRepository.findByIdAndStatus(DEST_ID, WalletStatus.ACTIVE)).thenReturn(Optional.of(dest));
+        when(idempotencyService.deduplicateOrSave(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(transactionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // When
+        Transaction result = handler.handle(command(SOURCE_ID, DEST_ID, 3000L));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+        assertThat(result.getType()).isEqualTo(TransactionType.TRANSFER);
+        assertThat(result.getFromWalletId()).isEqualTo(SOURCE_ID);
+        assertThat(result.getToWalletId()).isEqualTo(DEST_ID);
+        assertThat(result.getAmount()).isEqualTo(3000L);
+        assertThat(source.getCurrentBalance()).isEqualTo(7_000L);
+        assertThat(dest.getCurrentBalance()).isEqualTo(8_000L);
+        verify(ledgerService).createDebitEntry(any(Transaction.class), eq(source), eq(3000L));
+        verify(ledgerService).createCreditEntry(any(Transaction.class), eq(dest), eq(3000L));
+        verify(eventPublisher).publishTransactionCreated(any(Transaction.class));
+    }
+
+
+
+    @Test
+    void shouldReturnExistingTransactionOnDuplicateKey() {
+        // Given
+        Transaction existing = Transaction.create("idem-key-1", TransactionType.TRANSFER,
+                SOURCE_ID, DEST_ID, 3000L, EUR, USER_ID);
+        existing.complete();
+
+        when(idempotencyService.findDuplicate("idem-key-1")).thenReturn(Optional.of(existing));
+
+        // When
+        Transaction result = handler.handle(command(SOURCE_ID, DEST_ID, 3000L));
+
+        // Then
+        assertThat(result).isSameAs(existing);
+        verifyNoInteractions(walletService, walletRepository, ledgerService, eventPublisher, transactionRepository);
+    }
+
+
+    @Test
+    void shouldThrowWhenSourceAndDestinationAreTheSameWallet() {
+        // Given
+        when(idempotencyService.findDuplicate(any())).thenReturn(Optional.empty());
+
+        // When / Then
+        var command = command(SOURCE_ID, SOURCE_ID, 3000L);
+        assertThatThrownBy(() -> handler.handle(command))
+                .isInstanceOf(InvalidWalletOperationException.class);
+
+        verifyNoInteractions(walletService, walletRepository, ledgerService, eventPublisher, transactionRepository);
+    }
+
+
+    @Test
+    void shouldThrowWhenWalletCurrenciesDoNotMatch() {
+        // Given
+        Wallet source = wallet(USER_ID, EUR, 10_000L);
+        Wallet dest   = wallet(UUID.randomUUID(), GBP, 5_000L);
+
+        when(idempotencyService.findDuplicate(any())).thenReturn(Optional.empty());
+        when(walletService.getActiveById(SOURCE_ID, USER_ID)).thenReturn(source);
+        when(walletRepository.findByIdAndStatus(DEST_ID, WalletStatus.ACTIVE)).thenReturn(Optional.of(dest));
+
+        // When / Then
+        var command = command(SOURCE_ID, DEST_ID, 3000L);
+        assertThatThrownBy(() -> handler.handle(command))
+                .isInstanceOf(CurrencyMismatchException.class);
+
+        verifyNoInteractions(ledgerService, eventPublisher, transactionRepository);
+    }
+
+
+    @Test
+    void shouldThrowWhenDestinationWalletNotFoundOrFrozen() {
+        // Given
+        Wallet source = wallet(USER_ID, EUR, 10_000L);
+
+        when(idempotencyService.findDuplicate(any())).thenReturn(Optional.empty());
+        when(walletService.getActiveById(SOURCE_ID, USER_ID)).thenReturn(source);
+        when(walletRepository.findByIdAndStatus(DEST_ID, WalletStatus.ACTIVE)).thenReturn(Optional.empty());
+
+        // When / Then
+        var command = command(SOURCE_ID, DEST_ID, 3000L);
+        assertThatThrownBy(() -> handler.handle(command))
+                .isInstanceOf(WalletNotFoundException.class);
+
+        verifyNoInteractions(ledgerService, eventPublisher, transactionRepository);
+    }
+}

--- a/src/test/java/com/payflow/application/command/WithdrawCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/WithdrawCommandHandlerTest.java
@@ -1,0 +1,108 @@
+package com.payflow.application.command;
+
+import com.payflow.application.service.IdempotencyService;
+import com.payflow.application.service.LedgerService;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionStatus;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.kafka.TransactionOutboxWriter;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import com.payflow.infrastructure.persistence.jpa.WalletRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawCommandHandlerTest {
+
+    @Mock
+    private WalletService walletService;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private LedgerService ledgerService;
+
+    @Mock
+    private TransactionOutboxWriter eventPublisher;
+
+    @InjectMocks
+    private WithdrawCommandHandler handler;
+
+    private static final UUID USER_ID   = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final Currency EUR   = Currency.getInstance("EUR");
+
+    private WithdrawCommandHandler.Command command(long amountCents) {
+        return new WithdrawCommandHandler.Command("idem-key-1", WALLET_ID, USER_ID, amountCents);
+    }
+
+    private Wallet activeWallet(long balance) {
+        Wallet wallet = Wallet.create(USER_ID, EUR);
+        wallet.credit(balance);
+        return wallet;
+    }
+
+
+
+    @Test
+    void shouldWithdrawDebitWalletAndReturnCompletedTransaction() {
+        // Given
+        Wallet wallet = activeWallet(10_000L);
+
+        when(idempotencyService.findDuplicate("idem-key-1")).thenReturn(Optional.empty());
+        when(walletService.getActiveById(WALLET_ID, USER_ID)).thenReturn(wallet);
+        when(idempotencyService.deduplicateOrSave(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(transactionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // When
+        Transaction result = handler.handle(command(3000L));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+        assertThat(result.getType()).isEqualTo(TransactionType.WITHDRAW);
+        assertThat(result.getFromWalletId()).isEqualTo(WALLET_ID);
+        assertThat(result.getToWalletId()).isNull();
+        assertThat(result.getAmount()).isEqualTo(3000L);
+        assertThat(wallet.getCurrentBalance()).isEqualTo(7_000L);
+        verify(ledgerService).createDebitEntry(any(Transaction.class), eq(wallet), eq(3000L));
+        verify(eventPublisher).publishTransactionCreated(any(Transaction.class));
+    }
+
+
+    @Test
+    void shouldReturnExistingTransactionOnDuplicateKey() {
+        // Given
+        Transaction existing = Transaction.create("idem-key-1", TransactionType.WITHDRAW,
+                WALLET_ID, null, 3000L, EUR, USER_ID);
+        existing.complete();
+
+        when(idempotencyService.findDuplicate("idem-key-1")).thenReturn(Optional.of(existing));
+
+        // When
+        Transaction result = handler.handle(command(3000L));
+
+        // Then
+        assertThat(result).isSameAs(existing);
+        verifyNoInteractions(walletService, walletRepository, ledgerService, eventPublisher, transactionRepository);
+    }
+}

--- a/src/test/java/com/payflow/application/query/TransactionQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/TransactionQueryHandlerTest.java
@@ -1,0 +1,39 @@
+package com.payflow.application.query;
+
+import com.payflow.domain.model.transaction.TransactionNotFoundException;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionQueryHandlerTest {
+
+    @Mock private TransactionRepository repository;
+
+    @InjectMocks
+    private TransactionQueryHandler handler;
+
+    @Test
+    void shouldThrowWhenTransactionNotFound() {
+        // Given
+        UUID transactionId  = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        when(repository.findByIdAndUserId(transactionId, userId))
+                .thenReturn(Optional.empty());
+
+        // When / Then
+        var query = new TransactionQueryHandler.GetTransactionQuery(transactionId, userId);
+
+        assertThatThrownBy(() -> handler.handle(query))
+                .isInstanceOf(TransactionNotFoundException.class);
+    }
+}

--- a/src/test/java/com/payflow/application/service/IdempotencyServiceTest.java
+++ b/src/test/java/com/payflow/application/service/IdempotencyServiceTest.java
@@ -1,0 +1,112 @@
+package com.payflow.application.service;
+
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.infrastructure.persistence.jpa.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IdempotencyServiceTest {
+
+    @Mock private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private IdempotencyService idempotencyService;
+
+    private static final String IDEM_KEY = "idem-key-1";
+    private static final UUID   WALLET_ID = UUID.randomUUID();
+    private static final UUID   USER_ID   = UUID.randomUUID();
+    private static final Currency EUR     = Currency.getInstance("EUR");
+
+    private Transaction pendingDeposit() {
+        return Transaction.create(IDEM_KEY, TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+    }
+
+
+    @Test
+    void shouldReturnExistingTransactionWhenKeyMatches() {
+        // Given
+        Transaction existing = pendingDeposit();
+        when(transactionRepository.findByIdempotencyKey(IDEM_KEY))
+                .thenReturn(Optional.of(existing));
+
+        // When
+        Optional<Transaction> result = idempotencyService.findDuplicate(IDEM_KEY);
+
+        // Then
+        assertThat(result).contains(existing);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoExistingTransactionFound() {
+        // Given
+        when(transactionRepository.findByIdempotencyKey(IDEM_KEY))
+                .thenReturn(Optional.empty());
+
+        // When
+        Optional<Transaction> result = idempotencyService.findDuplicate(IDEM_KEY);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+
+    @Test
+    void shouldSaveAndReturnTransactionOnFirstInsert() {
+        // Given
+        Transaction tx = pendingDeposit();
+        when(transactionRepository.save(tx)).thenReturn(tx);
+
+        // When
+        Transaction result = idempotencyService.deduplicateOrSave(tx);
+
+        // Then
+        assertThat(result).isSameAs(tx);
+    }
+
+    @Test
+    void shouldReturnWinnerWhenConcurrentInsertViolatesConstraint() {
+        // Given — two requests race; this thread loses the unique constraint
+        Transaction tx     = pendingDeposit();
+        Transaction winner = pendingDeposit();
+        when(transactionRepository.save(tx))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+        when(transactionRepository.findByIdempotencyKey(IDEM_KEY))
+                .thenReturn(Optional.of(winner));
+
+        // When
+        Transaction result = idempotencyService.deduplicateOrSave(tx);
+
+        // Then
+        assertThat(result).isSameAs(winner);
+    }
+
+    @Test
+    void shouldThrowWhenConstraintFiredButRecordStillNotFound() {
+        // Given — constraint violation with no record to re-fetch indicates data corruption
+        Transaction tx = pendingDeposit();
+        when(transactionRepository.save(tx))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+        when(transactionRepository.findByIdempotencyKey(IDEM_KEY))
+                .thenReturn(Optional.empty());
+
+        // When / Then
+        assertThatThrownBy(() -> idempotencyService.deduplicateOrSave(tx))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Idempotency constraint violated but record not found");
+    }
+}

--- a/src/test/java/com/payflow/application/service/LedgerServiceTest.java
+++ b/src/test/java/com/payflow/application/service/LedgerServiceTest.java
@@ -1,0 +1,94 @@
+package com.payflow.application.service;
+
+import com.payflow.domain.model.ledger.EntryType;
+import com.payflow.domain.model.ledger.LedgerEntry;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.persistence.jpa.LedgerEntryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LedgerServiceTest {
+
+    @Mock private LedgerEntryRepository ledgerEntryRepository;
+
+    @InjectMocks
+    private LedgerService ledgerService;
+
+    private static final UUID USER_ID   = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final Currency EUR   = Currency.getInstance("EUR");
+
+    private Transaction deposit() {
+        return Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+    }
+
+    private Transaction withdrawal() {
+        return Transaction.create("idem-key-1", TransactionType.WITHDRAW,
+                WALLET_ID, null, 3000L, EUR, USER_ID);
+    }
+
+    private Wallet walletWithBalance(long balance) {
+        Wallet wallet = Wallet.create(USER_ID, EUR);
+        wallet.credit(balance);
+        return wallet;
+    }
+
+
+    @Test
+    void shouldSaveCreditEntryWithCorrectFields() {
+        // Given
+        Transaction tx     = deposit();
+        Wallet wallet      = walletWithBalance(10_000L);
+
+        // When
+        ledgerService.createCreditEntry(tx, wallet, 3000L);
+
+        // Then
+        ArgumentCaptor<LedgerEntry> captor = ArgumentCaptor.forClass(LedgerEntry.class);
+        verify(ledgerEntryRepository).save(captor.capture());
+        LedgerEntry entry = captor.getValue();
+
+        assertThat(entry.getEntryType()).isEqualTo(EntryType.CREDIT);
+        assertThat(entry.getAmount()).isEqualTo(3000L);
+        assertThat(entry.getBalanceAfter()).isEqualTo(13_000L);   // 10_000 + 3_000
+        assertThat(entry.getWalletId()).isEqualTo(wallet.getId());
+        assertThat(entry.getTransactionId()).isEqualTo(tx.getId());
+    }
+
+
+
+    @Test
+    void shouldSaveDebitEntryWithCorrectFields() {
+        // Given
+        Transaction tx     = withdrawal();
+        Wallet wallet      = walletWithBalance(10_000L);
+
+        // When
+        ledgerService.createDebitEntry(tx, wallet, 3000L);
+
+        // Then
+        ArgumentCaptor<LedgerEntry> captor = ArgumentCaptor.forClass(LedgerEntry.class);
+        verify(ledgerEntryRepository).save(captor.capture());
+        LedgerEntry entry = captor.getValue();
+
+        assertThat(entry.getEntryType()).isEqualTo(EntryType.DEBIT);
+        assertThat(entry.getAmount()).isEqualTo(3000L);
+        assertThat(entry.getBalanceAfter()).isEqualTo(7_000L);    // 10_000 - 3_000
+        assertThat(entry.getWalletId()).isEqualTo(wallet.getId());
+        assertThat(entry.getTransactionId()).isEqualTo(tx.getId());
+    }
+}

--- a/src/test/java/com/payflow/domain/model/transaction/TransactionTest.java
+++ b/src/test/java/com/payflow/domain/model/transaction/TransactionTest.java
@@ -1,0 +1,47 @@
+package com.payflow.domain.model.transaction;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionTest {
+
+    private static final UUID USER_ID      = UUID.randomUUID();
+    private static final UUID WALLET_ID    = UUID.randomUUID();
+    private static final Currency EUR      = Currency.getInstance("EUR");
+
+    @Test
+    void shouldCreateTransactionWithPendingStatus() {
+        // When
+        Transaction tx = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+
+        // Then
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.PENDING);
+        assertThat(tx.getIdempotencyKey()).isEqualTo("idem-key-1");
+        assertThat(tx.getType()).isEqualTo(TransactionType.DEPOSIT);
+        assertThat(tx.getFromWalletId()).isNull();
+        assertThat(tx.getToWalletId()).isEqualTo(WALLET_ID);
+        assertThat(tx.getAmount()).isEqualTo(5000L);
+        assertThat(tx.getCurrency()).isEqualTo(EUR);
+        assertThat(tx.getUserId()).isEqualTo(USER_ID);
+        assertThat(tx.getCompletedAt()).isNull();
+    }
+
+    @Test
+    void shouldSetSuccessStatusAndCompletedAtOnComplete() {
+        // Given
+        Transaction tx = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+
+        // When
+        tx.complete();
+
+        // Then
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+        assertThat(tx.getCompletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/payflow/domain/model/user/UserTest.java
+++ b/src/test/java/com/payflow/domain/model/user/UserTest.java
@@ -1,7 +1,6 @@
 package com.payflow.domain.model.user;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/payflow/domain/model/user/UserTest.java
+++ b/src/test/java/com/payflow/domain/model/user/UserTest.java
@@ -1,0 +1,38 @@
+package com.payflow.domain.model.user;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User user(UserStatus status) {
+        return User.builder()
+                .email("test@payflow.com")
+                .passwordHash("hashed")
+                .fullName("Test User")
+                .status(status)
+                .build();
+    }
+
+    @Test
+    void shouldReturnEmailAsUsername() {
+        assertThat(user(UserStatus.ACTIVE).getUsername()).isEqualTo("test@payflow.com");
+    }
+
+
+    @Test
+    void shouldBeEnabledOnlyWhenActive() {
+        assertThat(user(UserStatus.ACTIVE).isEnabled()).isTrue();
+        assertThat(user(UserStatus.SUSPENDED).isEnabled()).isFalse();
+        assertThat(user(UserStatus.CLOSED).isEnabled()).isFalse();
+    }
+
+    @Test
+    void shouldBeLockedWhenSuspended() {
+        assertThat(user(UserStatus.SUSPENDED).isAccountNonLocked()).isFalse();
+        assertThat(user(UserStatus.ACTIVE).isAccountNonLocked()).isTrue();
+        assertThat(user(UserStatus.CLOSED).isAccountNonLocked()).isTrue();
+    }
+}

--- a/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
+++ b/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
@@ -57,4 +57,27 @@ class WalletTest {
         // Then
         assertThat(wallet.getCurrentBalance()).isEqualTo(500L);
     }
+
+    @Test
+    void shouldFreezeActiveWallet() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+
+        // When
+        wallet.freeze();
+
+        // Then
+        assertThat(wallet.getStatus()).isEqualTo(WalletStatus.FROZEN);
+    }
+
+    @Test
+    void shouldThrowWhenFreezingNonActiveWallet() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+        wallet.freeze();
+
+        // When / Then
+        assertThatThrownBy(wallet::freeze)
+                .isInstanceOf(IllegalStateException.class);
+    }
 }

--- a/src/test/java/com/payflow/infrastructure/kafka/TransactionOutboxWriterTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/TransactionOutboxWriterTest.java
@@ -1,0 +1,108 @@
+package com.payflow.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.payflow.domain.model.outbox.OutboxEvent;
+import com.payflow.domain.model.outbox.OutboxEventStatus;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.infrastructure.persistence.jpa.OutboxRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionOutboxWriterTest {
+
+    @Mock private OutboxRepository outboxRepository;
+
+    private TransactionOutboxWriter writer;
+
+    private static final UUID USER_ID   = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final Currency EUR   = Currency.getInstance("EUR");
+
+    @BeforeEach
+    void setUp() {
+        // real ObjectMapper so serialization is actually exercised
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        writer = new TransactionOutboxWriter(outboxRepository, objectMapper);
+    }
+
+    @Test
+    void shouldSaveOutboxEventWithCorrectFields() {
+        // Given
+        Transaction tx = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+        tx.complete();
+
+        // When
+        writer.publishTransactionCreated(tx);
+
+        // Then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxRepository).save(captor.capture());
+        OutboxEvent event = captor.getValue();
+
+        assertThat(event.getAggregateId()).isEqualTo(tx.getId());
+        assertThat(event.getAggregateType()).isEqualTo("Transaction");
+        assertThat(event.getEventType()).isEqualTo("TransactionCreated");
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(event.getPayload()).isNotBlank();
+    }
+
+    @Test
+    void shouldSerializePayloadAsValidJson() throws Exception {
+        // Given
+        Transaction tx = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+        tx.complete();
+
+        // When
+        writer.publishTransactionCreated(tx);
+
+        // Then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxRepository).save(captor.capture());
+
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        TransactionOutboxWriter.TransactionCreatedPayload payload = mapper.readValue(
+                captor.getValue().getPayload(),
+                TransactionOutboxWriter.TransactionCreatedPayload.class
+        );
+        assertThat(payload.transactionId()).isEqualTo(tx.getId());
+        assertThat(payload.type()).isEqualTo(TransactionType.DEPOSIT);
+        assertThat(payload.amountCents()).isEqualTo(5000L);
+        assertThat(payload.currency()).isEqualTo(EUR);
+    }
+
+    @Test
+    void shouldThrowWhenSerializationFails() {
+        // Given — ObjectMapper that always fails
+        ObjectMapper broken = new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) throws com.fasterxml.jackson.core.JsonProcessingException {
+                throw new JsonGenerationException("forced failure", (JsonGenerator) null);
+            }
+        };
+        TransactionOutboxWriter brokenWriter = new TransactionOutboxWriter(outboxRepository, broken);
+        Transaction tx = Transaction.create("idem-key-1", TransactionType.DEPOSIT,
+                null, WALLET_ID, 5000L, EUR, USER_ID);
+
+        // When / Then
+        assertThatThrownBy(() -> brokenWriter.publishTransactionCreated(tx))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## What
Adds a comprehensive Mockito unit test suite covering all transaction command handlers, application services, domain models, and the outbox writer, plus fixes three production bugs discovered during the process.

## Linked Issue
Closes #37

## Why
Transaction command handlers (deposit, withdraw, transfer) had zero test coverage. During test authoring, three bugs were found and fixed: `WithdrawCommandHandler` and `TransferCommandHandler` were writing the ledger entry *after* mutating the cached balance, causing `balanceAfter` to double-subtract. `TransferCommandHandler` was also checking destination wallet ownership against the requesting user's ID, making cross-user transfers impossible despite the comment stating otherwise.

## Changes
**Bug fixes — application layer:**
- `WithdrawCommandHandler` — ledger entry now written before `wallet.debit()` (was double-subtracting `balanceAfter`)
- `TransferCommandHandler` source side — same ledger-before-debit fix
- `TransferCommandHandler` destination — loads by `id + ACTIVE` only, no ownership check (fixes cross-user transfers)

**Production code additions:**
- `DepositCommandHandler.Command` — compact constructor validates `amountCents > 0` (fail-fast before any DB calls)
- `LedgerEntry` — added `@Getter` (required for test assertions)
- `WalletRepository` — added `findByIdAndStatus` for destination wallet loading without ownership check
- `CLAUDE.md` — updated balance rule to reflect cached balance + ledger audit trail decision

**New test classes:**
- `DepositCommandHandlerTest`, `WithdrawCommandHandlerTest`, `TransferCommandHandlerTest`
- `IdempotencyServiceTest`, `LedgerServiceTest`
- `TransactionTest`, `UserTest`, `WalletTest` (freeze cases added)
- `TransactionQueryHandlerTest`, `TransactionOutboxWriterTest`

## Testing
All tests are Mockito unit tests — no Spring context, no Testcontainers. Each test class covers only the logic its class owns; collaborator behaviour is tested in its own class.

Cases covered per handler:
- Happy path — correct return value, balance mutation, ledger call, outbox event published
- Idempotency short-circuit — duplicate key returns existing transaction, all other collaborators untouched (`verifyNoInteractions`)
- `TransferCommandHandler` additionally covers: self-transfer rejection, currency mismatch, destination not found/frozen

`IdempotencyServiceTest` covers the `DataIntegrityViolationException` catch-and-refetch path and the `IllegalStateException` corruption edge case.

`TransactionOutboxWriterTest` uses a real `ObjectMapper` to verify payload serialisation round-trips correctly.

## Notes
- Insufficient balance is not tested at the handler layer — it is thrown inside `Wallet.debit()` and is already covered by `WalletTest.shouldThrowWhenDebitExceedsBalance`
- Integration tests (real DB + Kafka via Testcontainers) are deferred to a follow-up issue