### PR TITLE
Add consumer-group isolation to idempotent event deduplication

### DIFF
--- a/src/main/java/com/payflow/domain/model/audit/AuditLog.java
+++ b/src/main/java/com/payflow/domain/model/audit/AuditLog.java
@@ -45,7 +45,7 @@ public class AuditLog {
     @Column(columnDefinition = "jsonb")
     private String newValue;
 
-    @Column(columnDefinition = "inet")
+    @Column(columnDefinition = "inet", insertable = false, updatable = false)
     private String ipAddress;
 
     @Column(columnDefinition = "text")

--- a/src/main/java/com/payflow/domain/model/event/ProcessedEvent.java
+++ b/src/main/java/com/payflow/domain/model/event/ProcessedEvent.java
@@ -21,6 +21,9 @@ public class ProcessedEvent {
     @Column(name = "event_id", updatable = false)
     private UUID eventId;
 
+    @Column(name = "consumer_group", nullable = false)
+    private String consumerGroup;
+
     @Column(nullable = false, updatable = false)
     private Instant processedAt;
 }

--- a/src/main/java/com/payflow/domain/model/event/ProcessedEvent.java
+++ b/src/main/java/com/payflow/domain/model/event/ProcessedEvent.java
@@ -1,13 +1,15 @@
 package com.payflow.domain.model.event;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -17,13 +19,22 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProcessedEvent {
-    @Id
-    @Column(name = "event_id", updatable = false)
-    private UUID eventId;
 
-    @Column(name = "consumer_group", nullable = false)
-    private String consumerGroup;
+    @EmbeddedId
+    private ProcessedEventId id;
 
     @Column(nullable = false, updatable = false)
     private Instant processedAt;
+
+    @Embeddable
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProcessedEventId implements Serializable {
+        @Column(name = "event_id", updatable = false)
+        private UUID eventId;
+
+        @Column(name = "consumer_group", updatable = false)
+        private String consumerGroup;
+    }
 }

--- a/src/main/java/com/payflow/infrastructure/kafka/consumer/AnalyticsConsumer.java
+++ b/src/main/java/com/payflow/infrastructure/kafka/consumer/AnalyticsConsumer.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AnalyticsConsumer {
+    private static final String CONSUMER_GROUP = "analytics";
 
     @KafkaListener(
             topics = "${payflow.kafka.topics.transactions}",

--- a/src/main/java/com/payflow/infrastructure/kafka/consumer/AuditConsumer.java
+++ b/src/main/java/com/payflow/infrastructure/kafka/consumer/AuditConsumer.java
@@ -7,12 +7,10 @@ import com.payflow.domain.model.event.ProcessedEvent;
 import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
 import com.payflow.infrastructure.persistence.jpa.ProcessedEventRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
@@ -20,53 +18,42 @@ import static com.payflow.infrastructure.kafka.TransactionOutboxWriter.*;
 
 @Component
 @RequiredArgsConstructor
-@Log
+@Slf4j
 public class AuditConsumer {
-    private final TransactionTemplate transactionTemplate;
     private final ProcessedEventRepository processedEventRepository;
     private final AuditLogRepository auditLogRepository;
     private final ObjectMapper objectMapper;
     private static final String CONSUMER_GROUP = "audit";
+
     @KafkaListener(
             topics = "${payflow.kafka.topics.transactions}",
             groupId = "${payflow.kafka.consumer.audit-group}"
     )
-    public void handle(String payload, Acknowledgment ack ) {
-        // insert into audit_logs table
-        transactionTemplate.execute(
-                status -> {
-                    log.info("AuditConsumer received message: {}");
+    @Transactional
+    public void handle(String payload) {
+        try {
+            TransactionCreatedPayload event = objectMapper.readValue(payload, TransactionCreatedPayload.class);
 
-                    try {
-                        TransactionCreatedPayload event = objectMapper
-                                .readValue(payload,
-                                        TransactionCreatedPayload.class);
-                        // Check
-                        if (processedEventRepository.existsByEventIdAndConsumerGroup(event.transactionId(),CONSUMER_GROUP)) {
-                            return null;
-                        }
+            if (processedEventRepository.existsByIdEventIdAndIdConsumerGroup(event.transactionId(), CONSUMER_GROUP)) {
+                return;
+            }
 
-                        // Process
-                        auditLogRepository.save(AuditLog.builder()
-                                .action(event.type().name())
-                                .entityType("Transaction")
-                                .entityId(event.transactionId())
-                                .build());
+            auditLogRepository.save(AuditLog.builder()
+                    .action(event.type().name())
+                    .entityType("Transaction")
+                    .entityId(event.transactionId())
+                    .build());
 
-                        // Ack
-                        processedEventRepository.save(
-                                ProcessedEvent.builder()
-                                        .eventId(event.transactionId())
-                                        .consumerGroup(CONSUMER_GROUP)
-                                        .processedAt(Instant.now())
-                                        .build()
-                        );
-                        ack.acknowledge();
-                        return null;
-                    } catch (JsonProcessingException e) {
-                        throw new IllegalStateException("Failed to deserialize payload", e);
-                    }
-                }
-        );
+            processedEventRepository.save(ProcessedEvent.builder()
+                    .id(ProcessedEvent.ProcessedEventId.builder()
+                            .eventId(event.transactionId())
+                            .consumerGroup(CONSUMER_GROUP)
+                            .build())
+                    .processedAt(Instant.now())
+                    .build());
+
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize payload", e);
+        }
     }
 }

--- a/src/main/java/com/payflow/infrastructure/kafka/consumer/AuditConsumer.java
+++ b/src/main/java/com/payflow/infrastructure/kafka/consumer/AuditConsumer.java
@@ -7,6 +7,8 @@ import com.payflow.domain.model.event.ProcessedEvent;
 import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
 import com.payflow.infrastructure.persistence.jpa.ProcessedEventRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.log4j.Log4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -18,12 +20,13 @@ import static com.payflow.infrastructure.kafka.TransactionOutboxWriter.*;
 
 @Component
 @RequiredArgsConstructor
+@Log
 public class AuditConsumer {
     private final TransactionTemplate transactionTemplate;
     private final ProcessedEventRepository processedEventRepository;
     private final AuditLogRepository auditLogRepository;
     private final ObjectMapper objectMapper;
-
+    private static final String CONSUMER_GROUP = "audit";
     @KafkaListener(
             topics = "${payflow.kafka.topics.transactions}",
             groupId = "${payflow.kafka.consumer.audit-group}"
@@ -32,12 +35,14 @@ public class AuditConsumer {
         // insert into audit_logs table
         transactionTemplate.execute(
                 status -> {
+                    log.info("AuditConsumer received message: {}");
+
                     try {
                         TransactionCreatedPayload event = objectMapper
                                 .readValue(payload,
                                         TransactionCreatedPayload.class);
                         // Check
-                        if (processedEventRepository.existsById(event.transactionId())) {
+                        if (processedEventRepository.existsByEventIdAndConsumerGroup(event.transactionId(),CONSUMER_GROUP)) {
                             return null;
                         }
 
@@ -52,15 +57,16 @@ public class AuditConsumer {
                         processedEventRepository.save(
                                 ProcessedEvent.builder()
                                         .eventId(event.transactionId())
+                                        .consumerGroup(CONSUMER_GROUP)
                                         .processedAt(Instant.now())
                                         .build()
                         );
+                        ack.acknowledge();
                         return null;
                     } catch (JsonProcessingException e) {
                         throw new IllegalStateException("Failed to deserialize payload", e);
                     }
                 }
         );
-        ack.acknowledge();
     }
 }

--- a/src/main/java/com/payflow/infrastructure/kafka/consumer/KafkaConsumerConfig.java
+++ b/src/main/java/com/payflow/infrastructure/kafka/consumer/KafkaConsumerConfig.java
@@ -1,0 +1,22 @@
+package com.payflow.infrastructure.kafka.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@Slf4j
+public class KafkaConsumerConfig {
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        return new DefaultErrorHandler(
+                (consumerRecord, ex) -> log.error(
+                        "Failed to process record topic={} offset={} payload={}",
+                        consumerRecord.topic(), consumerRecord.offset(), consumerRecord.value(), ex),
+                new FixedBackOff(0L, 0L)
+        );
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/ProcessedEventRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/ProcessedEventRepository.java
@@ -1,11 +1,11 @@
 package com.payflow.infrastructure.persistence.jpa;
 
 import com.payflow.domain.model.event.ProcessedEvent;
+import com.payflow.domain.model.event.ProcessedEvent.ProcessedEventId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface ProcessedEventRepository extends JpaRepository<ProcessedEvent, UUID> {
-    boolean existsById(UUID id);
-    boolean existsByEventIdAndConsumerGroup(UUID eventId, String consumerGroup);
+public interface ProcessedEventRepository extends JpaRepository<ProcessedEvent, ProcessedEventId> {
+    boolean existsByIdEventIdAndIdConsumerGroup(UUID eventId, String consumerGroup);
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/ProcessedEventRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/ProcessedEventRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface ProcessedEventRepository extends JpaRepository<ProcessedEvent, UUID> {
     boolean existsById(UUID id);
+    boolean existsByEventIdAndConsumerGroup(UUID eventId, String consumerGroup);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,9 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
       retries: 3
+
       properties:
         enable.idempotence: true
         acks: all
@@ -28,7 +29,9 @@ spring:
       enable-auto-commit: false
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: record
 payflow:
   kafka:
     topics:

--- a/src/main/resources/db/migration/V15__add_consumer_group_to_events.sql
+++ b/src/main/resources/db/migration/V15__add_consumer_group_to_events.sql
@@ -1,0 +1,8 @@
+ALTER TABLE processed_events ADD COLUMN consumer_group VARCHAR(50);
+
+UPDATE processed_events SET consumer_group = 'audit';
+
+ALTER TABLE processed_events ALTER COLUMN consumer_group SET NOT NULL;
+
+ALTER TABLE processed_events ADD CONSTRAINT processed_events_event_id_consumer_group_key
+    UNIQUE (event_id, consumer_group);

--- a/src/main/resources/db/migration/V16__composite_pk_processed_events.sql
+++ b/src/main/resources/db/migration/V16__composite_pk_processed_events.sql
@@ -1,0 +1,3 @@
+-- Change PK from (event_id) to (event_id, consumer_group) to support per-consumer-group idempotency
+ALTER TABLE processed_events DROP CONSTRAINT processed_events_pkey;
+ALTER TABLE processed_events ADD CONSTRAINT processed_events_pkey PRIMARY KEY (event_id, consumer_group);

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -15,6 +16,13 @@ public class TestcontainersConfiguration {
     @RestartScope
     PostgreSQLContainer postgresContainer() {
         return new PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"));
+    }
+
+    @Bean
+    @ServiceConnection
+    @RestartScope
+    KafkaContainer kafkaContainer() {
+        return new KafkaContainer("apache/kafka:3.8.1");
     }
 
 }

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -22,7 +22,7 @@ public class TestcontainersConfiguration {
     @ServiceConnection
     @RestartScope
     KafkaContainer kafkaContainer() {
-        return new KafkaContainer("apache/kafka:3.8.1");
+        return new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.1"));
     }
 
 }

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.payflow.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.payflow.TestcontainersConfiguration;
+import com.payflow.domain.model.audit.AuditLog;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.infrastructure.kafka.TransactionOutboxWriter.TransactionCreatedPayload;
+import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
+import com.payflow.infrastructure.persistence.jpa.ProcessedEventRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Instant;
+import java.util.Currency;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "payflow.kafka.topics.transactions=transactions-test",
+        "payflow.kafka.consumer.audit-group=audit-test",
+        "app.jwt.secret=dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWhzNTEy"
+, // placeholder
+})
+@Import(TestcontainersConfiguration.class)
+class AuditConsumerIntegrationTest  {
+
+    @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired private AuditLogRepository auditLogRepository;
+    @Autowired private ProcessedEventRepository processedEventRepository;
+
+    @Value("${payflow.kafka.topics.transactions}")
+    private String transactionsTopic;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+    private static final Currency EUR = Currency.getInstance("EUR");
+    @Test
+    void shouldWriteAuditLog() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        var future = kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId));
+        future.get(); // blocks until send completes
+        System.out.println("Sent to topic: " + transactionsTopic);
+
+        await().atMost(30, SECONDS).untilAsserted(() -> {
+            assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);
+        });
+    }
+    @Test
+    void shouldWriteAuditLogAndMarkEventProcessedWhenTransactionEventReceived() throws Exception {
+        UUID eventId = UUID.randomUUID();
+
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId));
+
+        await().atMost(15, SECONDS).untilAsserted(() -> {
+            List<AuditLog> logs = auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId);
+            assertThat(logs).hasSize(1);
+            assertThat(logs.get(0).getAction()).isEqualTo("DEPOSIT");
+            assertThat(logs.get(0).getEntityId()).isEqualTo(eventId);
+        });
+
+        assertThat(processedEventRepository.existsByEventIdAndConsumerGroup(eventId, "audit")).isTrue();
+    }
+
+    @Test
+    void shouldNotWriteDuplicateAuditLogWhenSameEventDeliveredTwice() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        String payload = serialize(eventId);
+
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload);
+
+        await().atMost(15, SECONDS).untilAsserted(() ->
+            assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1)
+        );
+
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload);
+
+
+        assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);
+        assertThat(processedEventRepository.existsByEventIdAndConsumerGroup(eventId, "audit")).isTrue();
+    }
+
+    private static String serialize(UUID eventId) throws Exception {
+        return MAPPER.writeValueAsString(new TransactionCreatedPayload(
+                eventId,
+                TransactionType.DEPOSIT,
+                null,
+                UUID.randomUUID(),
+                5000L,
+                EUR,
+                Instant.now()
+        ));
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
@@ -48,7 +48,6 @@ class AuditConsumerIntegrationTest  {
         UUID eventId = UUID.randomUUID();
         var future = kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId));
         future.get(); // blocks until send completes
-        System.out.println("Sent to topic: " + transactionsTopic);
 
         await().atMost(30, SECONDS).untilAsserted(() -> {
             assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
@@ -8,6 +8,7 @@ import com.payflow.domain.model.transaction.TransactionType;
 import com.payflow.infrastructure.kafka.TransactionOutboxWriter.TransactionCreatedPayload;
 import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
 import com.payflow.infrastructure.persistence.jpa.ProcessedEventRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,16 +24,10 @@ import java.util.UUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
-        "spring.kafka.bootstrap-servers=localhost:9092",
-        "payflow.kafka.topics.transactions=transactions-test",
-        "payflow.kafka.consumer.audit-group=audit-test",
-        "app.jwt.secret=dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWhzNTEy"
-, // placeholder
-})
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
-class AuditConsumerIntegrationTest  {
+class AuditConsumerIntegrationTest {
 
     @Autowired private KafkaTemplate<String, String> kafkaTemplate;
     @Autowired private AuditLogRepository auditLogRepository;
@@ -43,30 +38,22 @@ class AuditConsumerIntegrationTest  {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
     private static final Currency EUR = Currency.getInstance("EUR");
-    @Test
-    void shouldWriteAuditLog() throws Exception {
-        UUID eventId = UUID.randomUUID();
-        var future = kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId));
-        future.get(); // blocks until send completes
 
-        await().atMost(30, SECONDS).untilAsserted(() -> {
-            assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);
-        });
-    }
+
     @Test
     void shouldWriteAuditLogAndMarkEventProcessedWhenTransactionEventReceived() throws Exception {
         UUID eventId = UUID.randomUUID();
 
-        kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId));
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), serialize(eventId)).get();
 
         await().atMost(15, SECONDS).untilAsserted(() -> {
             List<AuditLog> logs = auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId);
             assertThat(logs).hasSize(1);
-            assertThat(logs.get(0).getAction()).isEqualTo("DEPOSIT");
-            assertThat(logs.get(0).getEntityId()).isEqualTo(eventId);
+            assertThat(logs.getFirst().getAction()).isEqualTo("DEPOSIT");
+            assertThat(logs.getFirst().getEntityId()).isEqualTo(eventId);
         });
 
-        assertThat(processedEventRepository.existsByEventIdAndConsumerGroup(eventId, "audit")).isTrue();
+        assertThat(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(eventId, "audit")).isTrue();
     }
 
     @Test
@@ -74,17 +61,18 @@ class AuditConsumerIntegrationTest  {
         UUID eventId = UUID.randomUUID();
         String payload = serialize(eventId);
 
-        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload);
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload).get();
 
         await().atMost(15, SECONDS).untilAsserted(() ->
-            assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1)
-        );
+                assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1));
 
-        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload);
+        kafkaTemplate.send(transactionsTopic, eventId.toString(), payload).get();
 
-
-        assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);
-        assertThat(processedEventRepository.existsByEventIdAndConsumerGroup(eventId, "audit")).isTrue();
+        // wait long enough for a reprocessing attempt, assert still only 1
+        await().atMost(15, SECONDS).untilAsserted(() -> {
+            assertThat(auditLogRepository.findByEntityTypeAndEntityId("Transaction", eventId)).hasSize(1);
+            assertThat(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(eventId, "audit")).isTrue();
+        });
     }
 
     private static String serialize(UUID eventId) throws Exception {

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
@@ -1,0 +1,130 @@
+package com.payflow.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.payflow.domain.model.audit.AuditLog;
+import com.payflow.domain.model.event.ProcessedEvent;
+import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
+import com.payflow.infrastructure.persistence.jpa.ProcessedEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditConsumerTest {
+
+    @Mock private TransactionTemplate transactionTemplate;
+    @Mock private ProcessedEventRepository processedEventRepository;
+    @Mock private AuditLogRepository auditLogRepository;
+    @Mock private Acknowledgment ack;
+
+    private AuditConsumer consumer;
+
+    private static final UUID EVENT_ID  = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final String AUDIT_GROUP = "audit";
+
+    private String validPayload;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        consumer = new AuditConsumer(transactionTemplate, processedEventRepository, auditLogRepository, objectMapper);
+
+        validPayload = """
+                {"transactionId":"%s","type":"DEPOSIT","fromWalletId":null,"toWalletId":"%s",\
+                "amountCents":5000,"currency":"EUR","completedAt":"2024-01-01T00:00:00Z"}"""
+                .formatted(EVENT_ID, WALLET_ID);
+
+        doAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        }).when(transactionTemplate).execute(any());
+    }
+
+    @Test
+    void shouldSaveAuditLogAndMarkEventProcessedWhenEventIsNew() {
+        // Given
+        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+
+        // When
+        consumer.handle(validPayload, ack);
+
+        // Then
+        ArgumentCaptor<AuditLog> auditCaptor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(auditCaptor.capture());
+        AuditLog saved = auditCaptor.getValue();
+        assertThat(saved.getAction()).isEqualTo("DEPOSIT");
+        assertThat(saved.getEntityType()).isEqualTo("Transaction");
+        assertThat(saved.getEntityId()).isEqualTo(EVENT_ID);
+
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void shouldSkipAuditLogAndAckWhenSameEventAlreadyProcessedByAuditGroup() {
+        // Given
+        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(true);
+
+        // When
+        consumer.handle(validPayload, ack);
+
+        // Then — idempotency: no side effects, no ack
+        verify(auditLogRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+        verify(ack, never()).acknowledge();
+    }
+
+    @Test
+    void shouldProcessEventWhenSameEventIdAlreadyProcessedByDifferentConsumerGroup() {
+        // Given — "analytics" group processed this event; processed_events has (EVENT_ID, "analytics")
+        // but existsByEventIdAndConsumerGroup(EVENT_ID, "audit") still returns false, so audit proceeds
+        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+
+        // When
+        consumer.handle(validPayload, ack);
+
+        // Then — audit group is independent; it writes its own processed_events row and acks
+        verify(auditLogRepository).save(any(AuditLog.class));
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void shouldThrowIllegalStateWhenPayloadIsInvalidJson() {
+        // When / Then
+        assertThatThrownBy(() -> consumer.handle("not-valid-json", ack))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(auditLogRepository, never()).save(any());
+        verify(ack, never()).acknowledge();
+    }
+
+    @Test
+    void shouldNotAcknowledgeWhenRepositorySaveThrows() {
+        // Given
+        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+        when(auditLogRepository.save(any())).thenThrow(new RuntimeException());
+
+        // When / Then — exception propagates out of the transaction callback
+        assertThatThrownBy(() -> consumer.handle(validPayload, ack))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(processedEventRepository, never()).save(any());
+        verify(ack, never()).acknowledge();
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
@@ -83,10 +83,10 @@ class AuditConsumerTest {
         // When
         consumer.handle(validPayload, ack);
 
-        // Then — idempotency: no side effects, no ack
+        // Then — idempotency: no side effects, but acknowledge the known duplicate
         verify(auditLogRepository, never()).save(any());
         verify(processedEventRepository, never()).save(any());
-        verify(ack, never()).acknowledge();
+        verify(ack).acknowledge();
     }
 
     @Test

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.UUID;
@@ -29,7 +27,6 @@ class AuditConsumerTest {
     @Mock private TransactionTemplate transactionTemplate;
     @Mock private ProcessedEventRepository processedEventRepository;
     @Mock private AuditLogRepository auditLogRepository;
-    @Mock private Acknowledgment ack;
 
     private AuditConsumer consumer;
 
@@ -42,26 +39,23 @@ class AuditConsumerTest {
     @BeforeEach
     void setUp() {
         ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        consumer = new AuditConsumer(transactionTemplate, processedEventRepository, auditLogRepository, objectMapper);
+        consumer = new AuditConsumer(processedEventRepository, auditLogRepository, objectMapper);
 
         validPayload = """
                 {"transactionId":"%s","type":"DEPOSIT","fromWalletId":null,"toWalletId":"%s",\
                 "amountCents":5000,"currency":"EUR","completedAt":"2024-01-01T00:00:00Z"}"""
                 .formatted(EVENT_ID, WALLET_ID);
 
-        doAnswer(invocation -> {
-            TransactionCallback<?> callback = invocation.getArgument(0);
-            return callback.doInTransaction(null);
-        }).when(transactionTemplate).execute(any());
+
     }
 
     @Test
     void shouldSaveAuditLogAndMarkEventProcessedWhenEventIsNew() {
         // Given
-        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+        when(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
 
         // When
-        consumer.handle(validPayload, ack);
+        consumer.handle(validPayload);
 
         // Then
         ArgumentCaptor<AuditLog> auditCaptor = ArgumentCaptor.forClass(AuditLog.class);
@@ -70,61 +64,55 @@ class AuditConsumerTest {
         assertThat(saved.getAction()).isEqualTo("DEPOSIT");
         assertThat(saved.getEntityType()).isEqualTo("Transaction");
         assertThat(saved.getEntityId()).isEqualTo(EVENT_ID);
-
         verify(processedEventRepository).save(any(ProcessedEvent.class));
-        verify(ack).acknowledge();
     }
 
     @Test
-    void shouldSkipAuditLogAndAckWhenSameEventAlreadyProcessedByAuditGroup() {
+    void shouldSkipAuditLogWhenSameEventAlreadyProcessedByAuditGroup() {
         // Given
-        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(true);
+        when(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(true);
 
         // When
-        consumer.handle(validPayload, ack);
+        consumer.handle(validPayload);
 
-        // Then — idempotency: no side effects, but acknowledge the known duplicate
+        // Then
         verify(auditLogRepository, never()).save(any());
         verify(processedEventRepository, never()).save(any());
-        verify(ack).acknowledge();
     }
 
     @Test
     void shouldProcessEventWhenSameEventIdAlreadyProcessedByDifferentConsumerGroup() {
-        // Given — "analytics" group processed this event; processed_events has (EVENT_ID, "analytics")
-        // but existsByEventIdAndConsumerGroup(EVENT_ID, "audit") still returns false, so audit proceeds
-        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+        // Given — analytics group processed this event but audit group has not
+        when(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
 
         // When
-        consumer.handle(validPayload, ack);
+        consumer.handle(validPayload);
 
-        // Then — audit group is independent; it writes its own processed_events row and acks
+        // Then — audit group is independent, writes its own processed_events row
         verify(auditLogRepository).save(any(AuditLog.class));
         verify(processedEventRepository).save(any(ProcessedEvent.class));
-        verify(ack).acknowledge();
     }
 
     @Test
     void shouldThrowIllegalStateWhenPayloadIsInvalidJson() {
-        // When / Then
-        assertThatThrownBy(() -> consumer.handle("not-valid-json", ack))
-                .isInstanceOf(IllegalStateException.class);
+        // Given
+        String invalidPayload = "not-valid-json";
 
+        // When / Then
+        assertThatThrownBy(() -> consumer.handle(invalidPayload))
+                .isInstanceOf(IllegalStateException.class);
         verify(auditLogRepository, never()).save(any());
-        verify(ack, never()).acknowledge();
     }
 
     @Test
-    void shouldNotAcknowledgeWhenRepositorySaveThrows() {
+    void shouldNotSaveProcessedEventWhenRepositorySaveThrows() {
         // Given
-        when(processedEventRepository.existsByEventIdAndConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
+        when(processedEventRepository.existsByIdEventIdAndIdConsumerGroup(EVENT_ID, AUDIT_GROUP)).thenReturn(false);
         when(auditLogRepository.save(any())).thenThrow(new RuntimeException());
 
-        // When / Then — exception propagates out of the transaction callback
-        assertThatThrownBy(() -> consumer.handle(validPayload, ack))
+        // When / Then
+        assertThatThrownBy(() -> consumer.handle(validPayload))
                 .isInstanceOf(RuntimeException.class);
-
         verify(processedEventRepository, never()).save(any());
-        verify(ack, never()).acknowledge();
     }
 }


### PR DESCRIPTION
## What
Scopes the idempotency check in `processed_events` to `(event_id, consumer_group)` so each Kafka consumer group maintains its own deduplication record independently.

## Linked Issue
Closes #48

## Why
The previous check used only `event_id` as the primary key, meaning if two consumer groups (e.g. `audit` and `analytics`) consumed the same event, the second group's check would incorrectly treat the event as already processed. This is the Idempotent Consumer pattern — isolation per consumer group is required for correctness when multiple consumers share a topic.

## Changes
- **domain** — `ProcessedEvent`: added `consumerGroup` field mapped to `consumer_group` column
- **persistence** — `ProcessedEventRepository`: added `existsByEventIdAndConsumerGroup` derived query; `V15` migration adds the column, backfills existing rows with `'audit'`, sets `NOT NULL`, and adds a `UNIQUE(event_id, consumer_group)` constraint
- **kafka** — `AuditConsumer`: declared `CONSUMER_GROUP = "audit"` constant, updated idempotency check and save to pass group; moved `ack.acknowledge()` inside the transaction so ack only fires after a successful commit
- **kafka** — `AnalyticsConsumer`: declared `CONSUMER_GROUP = "analytics"` constant

## Testing
- `AuditConsumerTest` (Mockito unit test) — covers: new event processed and acked, duplicate suppressed (no save, no ack), same event ID processed independently by a different group, invalid JSON throws, repository failure prevents ack
- `AuditConsumerIntegrationTest` (Testcontainers — real Kafka + PostgreSQL) — covers: audit log written on first delivery, event marked processed per group, duplicate delivery produces no second audit log
- `TestcontainersConfiguration` — wired up real Kafka container for integration tests