### PR TITLE
Add Redis caching for wallets and JWT access token denylist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,20 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.redis</groupId>
+            <artifactId>testcontainers-redis</artifactId>
+            <version>2.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/payflow/PayflowApplication.java
+++ b/src/main/java/com/payflow/PayflowApplication.java
@@ -2,10 +2,12 @@ package com.payflow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableRetry
+@EnableCaching
 public class PayflowApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/payflow/PayflowApplication.java
+++ b/src/main/java/com/payflow/PayflowApplication.java
@@ -2,12 +2,10 @@ package com.payflow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableRetry
-@EnableCaching
 public class PayflowApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/payflow/PayflowApplication.java
+++ b/src/main/java/com/payflow/PayflowApplication.java
@@ -7,7 +7,6 @@ import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableRetry
-@EnableCaching
 public class PayflowApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/payflow/api/controller/AuthController.java
+++ b/src/main/java/com/payflow/api/controller/AuthController.java
@@ -62,8 +62,19 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestBody LogoutRequest request) {
-        logoutCommandHandler.handle(new LogoutCommandHandler.Command(request.refreshToken()));
+    public ResponseEntity<Void> logout(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody LogoutRequest request
+    ) {
+        String accessToken = authHeader.substring(7);
+        String jti = jwtService.extractJti(accessToken);
+        long ttlSeconds = (jwtService.extractExpiration(accessToken).getTime() - System.currentTimeMillis()) / 1000;
+
+        logoutCommandHandler.handle(new LogoutCommandHandler.Command(
+                jti,
+                Math.max(ttlSeconds, 0),
+                request.refreshToken()
+        ));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/payflow/api/controller/AuthController.java
+++ b/src/main/java/com/payflow/api/controller/AuthController.java
@@ -66,10 +66,18 @@ public class AuthController {
             @RequestHeader("Authorization") String authHeader,
             @RequestBody LogoutRequest request
     ) {
-        String accessToken = authHeader.substring(7);
-        String jti = jwtService.extractJti(accessToken);
-        long ttlSeconds = (jwtService.extractExpiration(accessToken).getTime() - System.currentTimeMillis()) / 1000;
+        String accessToken = jwtService.extractBearerToken(authHeader);
+        if (accessToken == null) {
+            return ResponseEntity.status(401).build();
+        }
 
+        String jti = jwtService.extractJti(accessToken);
+        java.util.Date expiration = jwtService.extractExpiration(accessToken);
+        if (jti == null || expiration == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        long ttlSeconds = (expiration.getTime() - System.currentTimeMillis()) / 1000;
         logoutCommandHandler.handle(new LogoutCommandHandler.Command(
                 jti,
                 Math.max(ttlSeconds, 0),

--- a/src/main/java/com/payflow/application/command/auth/LogoutCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/LogoutCommandHandler.java
@@ -23,11 +23,14 @@ public class LogoutCommandHandler {
     // Week 3: redisTemplate.opsForValue().set("denylist:" + command.tokenJti(), ...)
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public void handle(Command command) {
-        redisTemplate.opsForValue().set(
-                "denylist:" + command.tokenJti(),
-                "1",
-                Duration.ofSeconds(command.remainingTtlSeconds())
-        );
+        long remainingTtlSeconds = command.remainingTtlSeconds();
+        if (remainingTtlSeconds > 0) {
+            redisTemplate.opsForValue().set(
+                    "denylist:" + command.tokenJti(),
+                    "1",
+                    Duration.ofSeconds(remainingTtlSeconds)
+            );
+        }
         refreshTokenService.revoke(
                 command.rawRefreshToken()
         );

--- a/src/main/java/com/payflow/application/command/auth/LogoutCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/LogoutCommandHandler.java
@@ -2,9 +2,12 @@ package com.payflow.application.command.auth;
 
 import com.payflow.application.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 
 @Service
@@ -13,14 +16,20 @@ public class LogoutCommandHandler {
 
     // Week 1: token string
     // Week 3: tokenJti
-    public record Command(String token) {}
+    public record Command(String tokenJti, long remainingTtlSeconds, String rawRefreshToken) {}
     private final RefreshTokenService refreshTokenService;
+    private final StringRedisTemplate redisTemplate;
     // Week 1: no-op, client discards token
     // Week 3: redisTemplate.opsForValue().set("denylist:" + command.tokenJti(), ...)
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public void handle(Command command) {
+        redisTemplate.opsForValue().set(
+                "denylist:" + command.tokenJti(),
+                "1",
+                Duration.ofSeconds(command.remainingTtlSeconds())
+        );
         refreshTokenService.revoke(
-                command.token()
+                command.rawRefreshToken()
         );
     }
 }

--- a/src/main/java/com/payflow/application/command/auth/RegisterCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/RegisterCommandHandler.java
@@ -5,13 +5,13 @@ package com.payflow.application.command.auth;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.user.UserStatus;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.repository.RefreshTokenRepository;
 import com.payflow.domain.repository.UserRepository;
-import com.payflow.domain.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -29,7 +29,7 @@ public class RegisterCommandHandler {
     public record Command(String email, String password, String fullName) {}
 
     private final UserRepository userRepository;
-    private final WalletRepository walletRepository;
+    private final WalletService walletService;
     private final PasswordEncoder passwordEncoder;
     private final TokenPort tokenPort;
 
@@ -47,7 +47,7 @@ public class RegisterCommandHandler {
         userRepository.save(user);
 
         Wallet wallet = Wallet.create(user.getId(), Currency.getInstance("GBP"));
-        walletRepository.save(wallet);
+        walletService.save(wallet);
         String accessToken = tokenPort.generateAccessToken(user);
         String rawRefreshToken = refreshTokenService.issue(user.getId());
         return AuthenticationResponse.builder()

--- a/src/main/java/com/payflow/application/command/transactions/DepositCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/transactions/DepositCommandHandler.java
@@ -84,7 +84,7 @@ public class DepositCommandHandler {
 
         // STEP 6: Update cached balance after the ledger is written
         wallet.credit(command.amountCents());
-        walletRepository.save(wallet);
+        walletService.save(wallet);
 
         // STEP 7: Mark complete and persist
         tx.complete();

--- a/src/main/java/com/payflow/application/command/transactions/TransferCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/transactions/TransferCommandHandler.java
@@ -97,12 +97,12 @@ public class TransferCommandHandler {
         // STEP 6: Debit source — ledger first, then mutate cached balance
         ledgerService.createDebitEntry(tx, sourceWallet, command.amountCents());
         sourceWallet.debit(command.amountCents());
-        walletRepository.save(sourceWallet);
+        walletService.save(sourceWallet);
 
         // STEP 7: Credit destination
         ledgerService.createCreditEntry(tx, destinationWallet, command.amountCents());
         destinationWallet.credit(command.amountCents());
-        walletRepository.save(destinationWallet);
+        walletService.save(destinationWallet);
 
         // STEP 8: Mark complete and persist
         tx.complete();

--- a/src/main/java/com/payflow/application/command/transactions/WithdrawCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/transactions/WithdrawCommandHandler.java
@@ -89,7 +89,7 @@ public class WithdrawCommandHandler {
 
         // STEP 6: Debit cached balance after the ledger is written
         wallet.debit(command.amountCents());
-        walletRepository.save(wallet);
+        walletService.save(wallet);
 
         // STEP 7: Mark complete and persist
         tx.complete();

--- a/src/main/java/com/payflow/application/command/wallet/CreateWalletCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/wallet/CreateWalletCommandHandler.java
@@ -1,6 +1,7 @@
 package com.payflow.application.command.wallet;
 
 import com.payflow.api.dto.response.WalletResponse;
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletAlreadyExistsException;
 import com.payflow.domain.repository.WalletRepository;
@@ -19,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CreateWalletCommandHandler {
+
+    private final WalletService walletService;
 
     public record Command(UUID userId, Currency currency) {}
 
@@ -39,7 +42,7 @@ public class CreateWalletCommandHandler {
             throw new WalletAlreadyExistsException(command.userId(), command.currency());
         }
         Wallet wallet = Wallet.create(command.userId(), command.currency());
-        walletRepository.save(wallet);
+        walletService.save(wallet);
         return WalletResponse.from(wallet);
     }
 }

--- a/src/main/java/com/payflow/application/command/wallet/FreezeWalletCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/wallet/FreezeWalletCommandHandler.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.wallet;
 
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletNotFoundException;
 import com.payflow.domain.repository.WalletRepository;
@@ -21,6 +22,7 @@ public class FreezeWalletCommandHandler {
     public record Command(UUID walletId, UUID userId) {}
 
     private final WalletRepository walletRepository;
+    private final WalletService walletService;
 
     @Retryable(
             retryFor = {ObjectOptimisticLockingFailureException.class, PessimisticLockingFailureException.class},
@@ -37,6 +39,6 @@ public class FreezeWalletCommandHandler {
                 .orElseThrow(() -> new WalletNotFoundException(command.walletId()));
 
         wallet.freeze();
-        walletRepository.save(wallet);
+        walletService.save(wallet);
     }
 }

--- a/src/main/java/com/payflow/application/service/WalletService.java
+++ b/src/main/java/com/payflow/application/service/WalletService.java
@@ -4,8 +4,9 @@ import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletNotFoundException;
 import com.payflow.domain.model.wallet.WalletStatus;
 import com.payflow.domain.repository.WalletRepository;
-import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
+import org.springframework.cache.annotation.Cacheable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -14,9 +15,14 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class WalletService {
     private final WalletRepository walletRepository;
+    @Cacheable(value = "wallets", key = "#walletId + ':' + #requestingUserId")
     public Wallet getActiveById(UUID walletId, UUID requestingUserId) {
         return walletRepository.findByIdAndUserIdAndStatus(walletId,requestingUserId, WalletStatus.ACTIVE).orElseThrow(
                 () -> new WalletNotFoundException(walletId)
         );
+    }
+    @CacheEvict(value = "wallets", key = "#wallet.id + ':' + #wallet.userId")
+    public Wallet save(Wallet wallet) {
+        return walletRepository.save(wallet);
     }
 }

--- a/src/main/java/com/payflow/infrastructure/CacheConfig.java
+++ b/src/main/java/com/payflow/infrastructure/CacheConfig.java
@@ -1,0 +1,38 @@
+package com.payflow.infrastructure;
+
+
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig implements CachingConfigurer {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisSerializationContext.SerializationPair<Object> jsonSerializer =
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                        RedisSerializer.json()
+                );
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeValuesWith(jsonSerializer);
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+
+}

--- a/src/main/java/com/payflow/infrastructure/CacheConfig.java
+++ b/src/main/java/com/payflow/infrastructure/CacheConfig.java
@@ -32,6 +32,7 @@ public class CacheConfig implements CachingConfigurer {
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(config)
+                .transactionAware()
                 .build();
     }
 

--- a/src/main/java/com/payflow/infrastructure/datasource/DataSourceConfig.java
+++ b/src/main/java/com/payflow/infrastructure/datasource/DataSourceConfig.java
@@ -16,7 +16,9 @@ public class DataSourceConfig {
     @Bean
     @ConfigurationProperties("spring.datasource.write")
     public DataSourceProperties writeDataSourceProperties() {
-        return new DataSourceProperties();
+        DataSourceProperties props = new DataSourceProperties();
+        System.out.println("### WRITE URL: " + props.getUrl());
+        return props;
     }
 
     @Bean
@@ -50,12 +52,11 @@ public class DataSourceConfig {
     @Bean
     @Primary
     public DataSource dataSource() {
+        HikariDataSource write = writeDataSource();
+        HikariDataSource read = readDataSource();
         var routing = new RoutingDataSource();
-        routing.setTargetDataSources(Map.of(
-                "write", writeDataSource(),
-                "read", readDataSource()
-        ));
-        routing.setDefaultTargetDataSource(writeDataSource());
+        routing.setTargetDataSources(Map.of("write", write, "read", read));
+        routing.setDefaultTargetDataSource(write);
         return routing;
     }
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface UserJpaRepository extends JpaRepository<User, UUID>, UserRepository {
 
     Optional<User> findById(UUID userId);
+    @Override
+    User save(User user);
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletJpaRepository.java
@@ -1,15 +1,12 @@
 package com.payflow.infrastructure.persistence.jpa;
 
 import com.payflow.domain.model.wallet.Wallet;
-import com.payflow.domain.model.wallet.WalletStatus;
 import com.payflow.domain.repository.WalletRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Currency;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface WalletJpaRepository extends JpaRepository<Wallet, UUID>, WalletRepository {
-
+    @Override
+    Wallet save(Wallet wallet);
 }

--- a/src/main/java/com/payflow/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,6 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     protected void doFilterInternal(
@@ -40,6 +42,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
             if(jwtService.validateToken(jwt, userDetails)) {
+                String jti = jwtService.extractJti(jwt);
+                if (Boolean.TRUE.equals(redisTemplate.hasKey("denylist:" + jti))) {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails,
                         null,
                         userDetails.getAuthorities());

--- a/src/main/java/com/payflow/infrastructure/security/JwtService.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtService.java
@@ -23,7 +23,7 @@ public class JwtService extends TokenService implements TokenPort {
             return false;
         }
     }
-    private Date extractExpiration(String token) {
+    public Date extractExpiration(String token) {
         return extractClaim(token, Claims::getExpiration);
     }
 
@@ -43,6 +43,9 @@ public class JwtService extends TokenService implements TokenPort {
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
+    }
+    public String extractJti(String token) {
+        return extractClaim(token, Claims::getId);
     }
 
     private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {

--- a/src/main/java/com/payflow/infrastructure/security/TokenService.java
+++ b/src/main/java/com/payflow/infrastructure/security/TokenService.java
@@ -10,6 +10,7 @@ import javax.crypto.SecretKey;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class TokenService {
@@ -30,6 +31,7 @@ public class TokenService {
                 .subject(userDetails.getUsername())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis()+jwtExpiration))
+                .id(UUID.randomUUID().toString())
                 .signWith(getSignInKey(), Jwts.SIG.HS256).compact();
     }
 

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -14,7 +14,7 @@ spring:
     redis:
       host: redis
       port: 6379
-      timeout: 2000
+      timeout: 2000ms
   kafka:
     bootstrap-servers: kafka:9092
 

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -14,6 +14,7 @@ spring:
     redis:
       host: redis
       port: 6379
+      timeout: 2000
   kafka:
     bootstrap-servers: kafka:9092
 

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,23 +1,65 @@
 spring:
+  application:
+    name: payflow
+  profiles:
+    active: local
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    validate-on-migrate: true
+    out-of-order: false
   datasource:
     write:
-      url: jdbc:postgresql://postgres-primary:5432/payflow
-      username: ${DB_USER}
+      url: ${DB_WRITE_URL}
+      username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
-      driver-class-name: org.postgresql.Driver
     read:
-      url: jdbc:postgresql://postgres-replica:5432/payflow
-      username: ${DB_USER}
+      url: ${DB_READ_URL}
+      username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
-      driver-class-name: org.postgresql.Driver
-  data:
-    redis:
-      host: redis
-      port: 6379
-      timeout: 2000
-  kafka:
-    bootstrap-servers: kafka:9092
 
-logging:
-  level:
-    com.payflow: INFO
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      retries: 3
+
+      properties:
+        enable.idempotence: true
+        acks: all
+    consumer:
+      group-id: payflow-${spring.profiles.active}
+      enable-auto-commit: false
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: record
+payflow:
+  kafka:
+    topics:
+      transactions: transactions
+    consumer:
+      analytics-group: analytics-${spring.profiles.active}
+      audit-group: audit-${spring.profiles.active}
+  outbox:
+    poll-interval-ms: 500
+    batch-size: 100
+  retry:
+    max-attempts: 3
+    initial-interval-ms: 100
+    multiplier: 2.0
+    max-interval-ms: 1000
+
+app:
+  jwt:
+    secret: ${JWT_SECRET}
+    expiration: 900000
+    refresh-expiration: 604800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
       username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
 
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,6 @@ spring:
       username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
 
-
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:

--- a/src/test/java/com/payflow/BaseIntegrationTest.java
+++ b/src/test/java/com/payflow/BaseIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.payflow;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Testcontainers
+public abstract class BaseIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("payflow").withReuse(true);
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.write.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.write.username", postgres::getUsername);
+        registry.add("spring.datasource.write.password", postgres::getPassword);
+        registry.add("spring.datasource.read.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.read.username", postgres::getUsername);
+        registry.add("spring.datasource.read.password", postgres::getPassword);
+    }
+}

--- a/src/test/java/com/payflow/BaseIntegrationTest.java
+++ b/src/test/java/com/payflow/BaseIntegrationTest.java
@@ -1,21 +1,26 @@
 package com.payflow;
 
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
-@SpringBootTest
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
-@Testcontainers
+@AutoConfigureRestTestClient
 public abstract class BaseIntegrationTest {
 
-    @Container
-    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:18-alpine")
-            .withDatabaseName("payflow").withReuse(true);
+    static final PostgreSQLContainer postgres;
+
+    static {
+        postgres = new PostgreSQLContainer("postgres:18-alpine")
+                .withDatabaseName("payflow");
+        postgres.start();
+    }
+
 
     @DynamicPropertySource
     static void datasourceProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -5,32 +5,12 @@ import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.kafka.KafkaContainer;
-import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class TestcontainersConfiguration {
 
-    @Bean
-    @RestartScope
-    PostgreSQLContainer primaryContainer() {
-        return new PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"))
-                .withDatabaseName("payflow");
-    }
-
-    @Bean
-    DynamicPropertyRegistrar datasourceProperties(PostgreSQLContainer primaryContainer) {
-        return registry -> {
-            registry.add("spring.datasource.write.url", primaryContainer::getJdbcUrl);
-            registry.add("spring.datasource.write.username", primaryContainer::getUsername);
-            registry.add("spring.datasource.write.password", primaryContainer::getPassword);
-            registry.add("spring.datasource.read.url", primaryContainer::getJdbcUrl);
-            registry.add("spring.datasource.read.username", primaryContainer::getUsername);
-            registry.add("spring.datasource.read.password", primaryContainer::getPassword);
-        };
-    }
 
     @Bean
     @ServiceConnection
@@ -38,10 +18,11 @@ public class TestcontainersConfiguration {
     KafkaContainer kafkaContainer() {
         return new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.1"));
     }
+
     @Bean
     @ServiceConnection
     @RestartScope
     RedisContainer redisContainer() {
-        return new RedisContainer(DockerImageName.parse("redis:8.6-alpine"));
+        return new RedisContainer(DockerImageName.parse("redis:7-alpine"));
     }
 }

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -1,5 +1,6 @@
 package com.payflow;
 
+import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -36,5 +37,11 @@ public class TestcontainersConfiguration {
     @RestartScope
     KafkaContainer kafkaContainer() {
         return new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.1"));
+    }
+    @Bean
+    @ServiceConnection
+    @RestartScope
+    RedisContainer redisContainer() {
+        return new RedisContainer(DockerImageName.parse("redis:8.6-alpine"));
     }
 }

--- a/src/test/java/com/payflow/application/command/auth/LoginIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LoginIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.payflow.application.command.auth;
 
 
+import com.payflow.BaseIntegrationTest;
 import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.LoginRequest;
 import com.payflow.api.dto.request.RegisterRequest;
@@ -19,7 +20,7 @@ import java.util.UUID;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
 @AutoConfigureRestTestClient
-class LoginIntegrationTest {
+class LoginIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private RestTestClient restTestClient;

--- a/src/test/java/com/payflow/application/command/auth/LoginIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LoginIntegrationTest.java
@@ -2,7 +2,6 @@ package com.payflow.application.command.auth;
 
 
 import com.payflow.BaseIntegrationTest;
-import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.LoginRequest;
 import com.payflow.api.dto.request.RegisterRequest;
 import com.payflow.domain.repository.UserRepository;
@@ -10,16 +9,10 @@ import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestcontainersConfiguration.class)
-@AutoConfigureRestTestClient
 class LoginIntegrationTest extends BaseIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/payflow/application/command/auth/LogoutCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LogoutCommandHandlerTest.java
@@ -1,31 +1,57 @@
 package com.payflow.application.command.auth;
 
 import com.payflow.application.service.RefreshTokenService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
+
+import java.time.Duration;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LogoutCommandHandlerTest {
 
-    @Mock
-    private RefreshTokenService refreshTokenService;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock ValueOperations<String, String> valueOps;
+    @Mock RefreshTokenService refreshTokenService;
 
-    @InjectMocks
-    private LogoutCommandHandler handler;
+    @InjectMocks LogoutCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    }
+
+    @Test
+    void shouldWriteJtiToDenylistOnLogout() {
+        // Given
+        var command = new LogoutCommandHandler.Command("test-jti-123", 300L, "raw-refresh-token");
+
+        // When
+        handler.handle(command);
+
+        // Then
+        verify(valueOps).set("denylist:test-jti-123", "1", Duration.ofSeconds(300));
+    }
 
     @Test
     void shouldRevokeRefreshTokenOnLogout() {
-        String rawToken = "some-raw-token";
+        // Given
+        var command = new LogoutCommandHandler.Command("test-jti-123", 300L, "some-raw-token");
 
-        handler.handle(new LogoutCommandHandler.Command(rawToken));
+        // When
+        handler.handle(command);
 
-        verify(refreshTokenService).revoke(rawToken);
+        // Then
+        verify(refreshTokenService).revoke("some-raw-token");
     }
 }

--- a/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
@@ -1,18 +1,13 @@
 package com.payflow.application.command.auth;
 
 import com.payflow.BaseIntegrationTest;
-import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.LogoutRequest;
 import com.payflow.api.dto.request.RegisterRequest;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.domain.model.token.RefreshToken;
 import com.payflow.domain.repository.RefreshTokenRepository;
-import org.hibernate.boot.internal.Extends;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 import java.nio.charset.StandardCharsets;
@@ -23,8 +18,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureRestTestClient
 class LogoutIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private RestTestClient restTestClient;

--- a/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
@@ -1,11 +1,13 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.BaseIntegrationTest;
 import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.LogoutRequest;
 import com.payflow.api.dto.request.RegisterRequest;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.domain.model.token.RefreshToken;
 import com.payflow.domain.repository.RefreshTokenRepository;
+import org.hibernate.boot.internal.Extends;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
@@ -22,9 +24,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestcontainersConfiguration.class)
 @AutoConfigureRestTestClient
-class LogoutIntegrationTest {
+class LogoutIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private RestTestClient restTestClient;
     @Autowired private RefreshTokenRepository refreshTokenRepository;

--- a/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.BaseIntegrationTest;
 import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.RefreshRequest;
 import com.payflow.api.dto.request.RegisterRequest;
@@ -29,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
 @AutoConfigureRestTestClient
-class RefreshTokenIntegrationTest {
+class RefreshTokenIntegrationTest extends BaseIntegrationTest {
     @Autowired private RestTestClient restTestClient;
     @Autowired private RefreshTokenRepository refreshTokenRepository;
     @Autowired private UserJpaRepository userRepository;

--- a/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.payflow.application.command.auth;
 
 import com.payflow.BaseIntegrationTest;
-import com.payflow.TestcontainersConfiguration;
 import com.payflow.api.dto.request.RefreshRequest;
 import com.payflow.api.dto.request.RegisterRequest;
 import com.payflow.api.dto.response.AuthenticationResponse;
@@ -11,9 +10,6 @@ import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 import java.nio.charset.StandardCharsets;
@@ -27,9 +23,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestcontainersConfiguration.class)
-@AutoConfigureRestTestClient
 class RefreshTokenIntegrationTest extends BaseIntegrationTest {
     @Autowired private RestTestClient restTestClient;
     @Autowired private RefreshTokenRepository refreshTokenRepository;

--- a/src/test/java/com/payflow/application/command/auth/RegisterCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RegisterCommandHandlerTest.java
@@ -3,6 +3,7 @@ package com.payflow.application.command.auth;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.user.EmailAlreadyRegisteredException;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.wallet.Wallet;
@@ -32,6 +33,10 @@ class RegisterCommandHandlerTest {
 
     @Mock
     private WalletRepository walletRepository;
+
+
+    @Mock
+    private WalletService walletService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -66,7 +71,7 @@ class RegisterCommandHandlerTest {
         assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
         assertThat(response.getEmail()).isEqualTo("test@payflow.com");
         verify(userRepository).save(any(User.class));
-        verify(walletRepository).save(any(Wallet.class));
+        verify(walletService).save(any(Wallet.class));
         verify(passwordEncoder).encode("password123");
     }
 

--- a/src/test/java/com/payflow/application/command/auth/RegisterIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RegisterIntegrationTest.java
@@ -4,13 +4,11 @@ import com.payflow.BaseIntegrationTest;
 import com.payflow.api.dto.request.RegisterRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
+import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureRestTestClient
+
 class RegisterIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private RestTestClient restTestClient;
@@ -20,7 +18,7 @@ class RegisterIntegrationTest extends BaseIntegrationTest {
         restTestClient.post()
                 .uri("/api/v1/auth/register")
                 .body(RegisterRequest.builder()
-                        .email("register-happy@payflow.com")
+                        .email("register-" + UUID.randomUUID() + "@payflow.com")
                         .password("password123")
                         .fullName("Test User")
                         .build())
@@ -30,23 +28,18 @@ class RegisterIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void shouldReturn409WhenEmailAlreadyRegistered() {
+        String email = "register-" + UUID.randomUUID() + "@payflow.com";
         RegisterRequest request = RegisterRequest.builder()
-                .email("register-duplicate@payflow.com")
+                .email(email)
                 .password("password123")
                 .fullName("Test User")
                 .build();
 
-        restTestClient.post()
-                .uri("/api/v1/auth/register")
-                .body(request)
-                .exchange()
-                .expectStatus().isOk();
+        restTestClient.post().uri("/api/v1/auth/register").body(request)
+                .exchange().expectStatus().isOk();
 
-        restTestClient.post()
-                .uri("/api/v1/auth/register")
-                .body(request)
-                .exchange()
-                .expectStatus().isEqualTo(409);
+        restTestClient.post().uri("/api/v1/auth/register").body(request)
+                .exchange().expectStatus().isEqualTo(409);
     }
 
     @Test

--- a/src/test/java/com/payflow/application/command/auth/RegisterIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RegisterIntegrationTest.java
@@ -1,25 +1,19 @@
 package com.payflow.application.command.auth;
 
-import com.payflow.TestcontainersConfiguration;
+import com.payflow.BaseIntegrationTest;
 import com.payflow.api.dto.request.RegisterRequest;
-import com.payflow.domain.repository.UserRepository;
-import com.payflow.domain.repository.WalletRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestcontainersConfiguration.class)
 @AutoConfigureRestTestClient
-class RegisterIntegrationTest {
+class RegisterIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private RestTestClient restTestClient;
-    @Autowired private UserRepository userRepository;
-    @Autowired private WalletRepository walletRepository;
 
     @Test
     void shouldRegisterUserCreateWalletAndReturnTokens() {

--- a/src/test/java/com/payflow/application/command/wallet/CreateWalletCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/CreateWalletCommandHandlerTest.java
@@ -1,6 +1,7 @@
 package com.payflow.application.command.wallet;
 
 import com.payflow.api.dto.response.WalletResponse;
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletAlreadyExistsException;
 import com.payflow.domain.repository.WalletRepository;
@@ -25,6 +26,10 @@ class CreateWalletCommandHandlerTest {
     @Mock
     private WalletRepository walletRepository;
 
+
+    @Mock
+    private WalletService walletService;
+
     @InjectMocks
     private CreateWalletCommandHandler handler;
 
@@ -39,7 +44,7 @@ class CreateWalletCommandHandlerTest {
 
         assertThat(response.currency()).isEqualTo(EUR);
         assertThat(response.balance()).isZero();
-        verify(walletRepository).save(any(Wallet.class));
+        verify(walletService).save(any(Wallet.class));
     }
 
     @Test
@@ -51,6 +56,6 @@ class CreateWalletCommandHandlerTest {
         assertThatThrownBy(() -> handler.handle(new CreateWalletCommandHandler.Command(userId, EUR)))
                 .isInstanceOf(WalletAlreadyExistsException.class);
 
-        verify(walletRepository, never()).save(any());
+        verify(walletService, never()).save(any());
     }
 }

--- a/src/test/java/com/payflow/application/command/wallet/FreezeWalletCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/FreezeWalletCommandHandlerTest.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.wallet;
 
+import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.model.wallet.WalletNotFoundException;
 import com.payflow.domain.model.wallet.WalletStatus;
@@ -25,6 +26,10 @@ class FreezeWalletCommandHandlerTest {
     @Mock
     private WalletRepository walletRepository;
 
+
+    @Mock
+    private WalletService walletService;
+
     @InjectMocks
     private FreezeWalletCommandHandler handler;
 
@@ -37,7 +42,7 @@ class FreezeWalletCommandHandlerTest {
         handler.handle(new FreezeWalletCommandHandler.Command(wallet.getId(), userId));
 
         assertThat(wallet.getStatus()).isEqualTo(WalletStatus.FROZEN);
-        verify(walletRepository).save(wallet);
+        verify(walletService).save(wallet);
     }
 
     @Test
@@ -48,7 +53,7 @@ class FreezeWalletCommandHandlerTest {
         assertThatThrownBy(() -> handler.handle(new FreezeWalletCommandHandler.Command(walletId, UUID.randomUUID())))
                 .isInstanceOf(WalletNotFoundException.class);
 
-        verify(walletRepository, never()).save(any());
+        verify(walletService, never()).save(any());
     }
 
     @Test
@@ -61,7 +66,7 @@ class FreezeWalletCommandHandlerTest {
         assertThatThrownBy(() -> handler.handle(new FreezeWalletCommandHandler.Command(wallet.getId(), otherUserId)))
                 .isInstanceOf(WalletNotFoundException.class);
 
-        verify(walletRepository, never()).save(any());
+        verify(walletService, never()).save(any());
     }
 
     @Test

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.payflow.infrastructure;
 
+import com.payflow.BaseIntegrationTest;
 import com.payflow.TestcontainersConfiguration;
 import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.user.User;
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Import(TestcontainersConfiguration.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
-class CacheIntegrationTest {
+class CacheIntegrationTest  extends BaseIntegrationTest {
 
     @Autowired
     private WalletService walletService;

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.payflow.infrastructure;
+
+import com.payflow.TestcontainersConfiguration;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
+import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+
+class CacheIntegrationTest {
+
+    @Autowired
+    private WalletService walletService;
+
+    @Autowired
+    private WalletJpaRepository walletRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    private UUID walletId;
+    private UUID userId;
+
+    @Autowired
+    private UserJpaRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .email("test@payflow.com")
+                .fullName("Test User")
+                .passwordHash("test123").build();
+        user = userRepository.save(user);
+        userId = user.getId();
+
+        Wallet wallet = Wallet.create(userId, Currency.getInstance("EUR"));
+        wallet = walletService.save(wallet);
+        walletId = wallet.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        walletRepository.deleteAll();
+        userRepository.deleteAll();
+        cacheManager.getCache("wallets").clear();
+    }
+
+
+    @Test
+    void getActiveByIdFirstCallPopulatesCache() {
+        // Given
+        walletService.getActiveById(walletId, userId);
+
+        // When
+        Cache cache = cacheManager.getCache("wallets");
+
+        // Then
+        assertNotNull(cache.get(walletId + ":" + userId));
+    }
+
+    @Test
+    void getActiveByIdSecondCallReturnsCachedValue() {
+        // Given
+        Wallet first = walletService.getActiveById(walletId, userId);
+        Wallet second = walletService.getActiveById(walletId, userId);
+
+        // Then
+        assertEquals(first.getId(), second.getId());
+    }
+
+
+    @Test
+    void saveEvictsCache() {
+        // Given
+        walletService.getActiveById(walletId, userId);
+        assertNotNull(cacheManager.getCache("wallets")
+                .get(walletId + ":" + userId));
+
+        // When
+        Wallet wallet = walletService.getActiveById(walletId, userId);
+        walletService.save(wallet);
+
+        // Then
+        assertNull(cacheManager.getCache("wallets")
+                .get(walletId + ":" + userId));
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.payflow.infrastructure;
 
 import com.payflow.BaseIntegrationTest;
-import com.payflow.TestcontainersConfiguration;
 import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.wallet.Wallet;
@@ -9,18 +8,14 @@ import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
 import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.context.annotation.Import;
 
 import java.util.Currency;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@Import(TestcontainersConfiguration.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
 class CacheIntegrationTest  extends BaseIntegrationTest {

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.payflow.infrastructure.kafka.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.payflow.BaseIntegrationTest;
 import com.payflow.TestcontainersConfiguration;
 import com.payflow.domain.model.audit.AuditLog;
 import com.payflow.domain.model.transaction.TransactionType;
@@ -27,7 +28,7 @@ import static org.awaitility.Awaitility.await;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
-class AuditConsumerIntegrationTest {
+class AuditConsumerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private KafkaTemplate<String, String> kafkaTemplate;
     @Autowired private AuditLogRepository auditLogRepository;

--- a/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/kafka/consumer/AuditConsumerIntegrationTest.java
@@ -3,7 +3,6 @@ package com.payflow.infrastructure.kafka.consumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.payflow.BaseIntegrationTest;
-import com.payflow.TestcontainersConfiguration;
 import com.payflow.domain.model.audit.AuditLog;
 import com.payflow.domain.model.transaction.TransactionType;
 import com.payflow.infrastructure.kafka.TransactionOutboxWriter.TransactionCreatedPayload;
@@ -13,8 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Instant;
@@ -26,8 +23,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 @Slf4j
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestcontainersConfiguration.class)
 class AuditConsumerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private KafkaTemplate<String, String> kafkaTemplate;


### PR DESCRIPTION
## What
Introduces Redis as a shared cache layer: wallet reads are cached with `@Cacheable`/`@CacheEvict` via `WalletService`, and logout now writes the access token JTI to a Redis denylist that the JWT filter checks on every request.

## Linked Issue
Closes #50

## Why
Two failure modes addressed:
- **Repeated wallet reads on every transaction** hit the DB unnecessarily; caching the active wallet by `(walletId, userId)` with a 10-minute TTL cuts read load and keeps the read path O(1).
- **Stateless JWT logout gap** — previously a logged-out access token remained valid until expiry. Writing the JTI to a Redis denylist with a TTL equal to the token's remaining lifetime closes that window without requiring stateful sessions.

Both patterns use Redis' built-in TTL so no scheduled cleanup jobs are needed.

## Changes
**Infrastructure**
- `CacheConfig` — `RedisCacheManager` with JSON serialization and 10-min default TTL
- `TestcontainersConfiguration` — adds `RedisContainer` (`redis:8.6-alpine`) via `@ServiceConnection`

**Security / Auth**
- `TokenService` — JTI (`UUID`) now embedded in every issued JWT
- `JwtService` — `extractJti()` and `extractExpiration()` made public
- `JwtAuthenticationFilter` — checks `denylist:<jti>` in Redis before granting authentication
- `LogoutCommandHandler` / `AuthController` — logout extracts JTI + remaining TTL from the Authorization header and writes to the denylist before revoking the refresh token

**Wallet caching**
- `WalletService.getActiveById` — `@Cacheable(value = "wallets", key = "#walletId + ':' + #requestingUserId")`
- `WalletService.save` — `@CacheEvict` on the same key; all command handlers (deposit, withdraw, transfer, create wallet, freeze wallet, register) now route saves through `WalletService` instead of calling `WalletRepository` directly

## Testing
- `CacheIntegrationTest` (Testcontainers, real Redis) — covers cache population on first call, cache hit on second call, and eviction on save
- `LogoutCommandHandlerTest` (Mockito) — verifies JTI is written to the denylist with the correct TTL and that the refresh token is revoked

## Notes
- `@CacheEvict` is called inside the same `@Transactional(SERIALIZABLE)` command handler; the eviction fires on method exit so the cache entry is removed after the DB write commits.
- Denylist TTL is clamped to `max(remainingTtl, 0)` to avoid negative durations on already-expired tokens.