### PR TITLE
Add TimescaleDB hypertable and nightly reconciliation alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres-primary:
-        image: postgres:18-alpine
+        image: timescale/timescaledb:2.17.2-pg18
         env:
           POSTGRES_DB: payflow
           POSTGRES_USER: dev
@@ -24,7 +24,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres-replica:
-        image: postgres:18-alpine
+        image: timescale/timescaledb:2.17.2-pg18
         env:
           POSTGRES_DB: payflow
           POSTGRES_USER: dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres-primary:
-        image: timescale/timescaledb:2.17.2-pg18
+        image: timescale/timescaledb:latest-pg18
         env:
           POSTGRES_DB: payflow
           POSTGRES_USER: dev
@@ -24,7 +24,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres-replica:
-        image: timescale/timescaledb:2.17.2-pg18
+        image: timescale/timescaledb:latest-pg18
         env:
           POSTGRES_DB: payflow
           POSTGRES_USER: dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres-primary:
-    image: postgres:18-alpine
+    image: timescale/timescaledb:latest-pg18
     container_name: payflow-postgres-primary
     environment:
       POSTGRES_DB: payflow
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   postgres-replica:
-    image: postgres:18-alpine
+    image: timescale/timescaledb:latest-pg18
     container_name: payflow-postgres-replica
     environment:
       POSTGRES_DB: payflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres-primary:
-    image: timescale/timescaledb:latest-pg18
+    image: timescale/timescaledb:2.17.2-pg18
     container_name: payflow-postgres-primary
     environment:
       POSTGRES_DB: payflow
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   postgres-replica:
-    image: timescale/timescaledb:latest-pg18
+    image: timescale/timescaledb:2.17.2-pg18
     container_name: payflow-postgres-replica
     environment:
       POSTGRES_DB: payflow

--- a/src/main/java/com/payflow/PayflowApplication.java
+++ b/src/main/java/com/payflow/PayflowApplication.java
@@ -3,9 +3,11 @@ package com.payflow;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableRetry
+@EnableScheduling
 public class PayflowApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/payflow/domain/model/AlertType.java
+++ b/src/main/java/com/payflow/domain/model/AlertType.java
@@ -1,0 +1,6 @@
+package com.payflow.domain.model;
+
+public enum AlertType {
+    GLOBAL_IMBALANCE,
+    WALLET_CACHE_DISCREPANCY
+}

--- a/src/main/java/com/payflow/domain/model/ReconciliationAlert.java
+++ b/src/main/java/com/payflow/domain/model/ReconciliationAlert.java
@@ -1,0 +1,35 @@
+package com.payflow.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+@Entity
+@Table(name = "reconciliation_alerts")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReconciliationAlert {
+    @Id
+    @UuidGenerator
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlertType type;
+
+    @Column(nullable = false)
+    private String detail;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant occurredAt;
+
+}

--- a/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
+++ b/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
@@ -4,4 +4,5 @@ import com.payflow.domain.model.ledger.LedgerEntry;
 
 public interface LedgerEntryRepository {
     LedgerEntry save(LedgerEntry ledgerEntry);
+    void deleteAll();
 }

--- a/src/main/java/com/payflow/domain/repository/ReconciliationAlertRepository.java
+++ b/src/main/java/com/payflow/domain/repository/ReconciliationAlertRepository.java
@@ -1,0 +1,11 @@
+package com.payflow.domain.repository;
+
+import com.payflow.domain.model.ReconciliationAlert;
+
+import java.util.List;
+
+public interface ReconciliationAlertRepository {
+    ReconciliationAlert save(ReconciliationAlert reconciliationAlert);
+    List<ReconciliationAlert> findAll();
+    void deleteAll();
+}

--- a/src/main/java/com/payflow/domain/repository/WalletRepository.java
+++ b/src/main/java/com/payflow/domain/repository/WalletRepository.java
@@ -16,4 +16,5 @@ public interface WalletRepository {
     Optional<Wallet> findByIdAndUserIdAndStatus(UUID id, UUID userId, WalletStatus status);
     Optional<Wallet> findByIdAndStatus(UUID id, WalletStatus status);
     Wallet save(Wallet wallet);
+    void deleteAll();
 }

--- a/src/main/java/com/payflow/infrastructure/CacheConfig.java
+++ b/src/main/java/com/payflow/infrastructure/CacheConfig.java
@@ -1,16 +1,17 @@
 package com.payflow.infrastructure;
 
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.RedisSerializer;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
 import java.time.Duration;
 
@@ -20,10 +21,19 @@ public class CacheConfig implements CachingConfigurer {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.builder()
+                .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(Object.class)
+                        .build())
+                .customize(builder -> builder
+                        .findAndAddModules()
+                        .changeDefaultVisibility(vc -> vc
+                                .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                                .withVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NON_PRIVATE)))
+                .build();
+
         RedisSerializationContext.SerializationPair<Object> jsonSerializer =
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                        RedisSerializer.json()
-                );
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer);
 
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
@@ -32,8 +42,6 @@ public class CacheConfig implements CachingConfigurer {
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(config)
-                .transactionAware()
                 .build();
     }
-
 }

--- a/src/main/java/com/payflow/infrastructure/datasource/DataSourceConfig.java
+++ b/src/main/java/com/payflow/infrastructure/datasource/DataSourceConfig.java
@@ -17,14 +17,13 @@ public class DataSourceConfig {
     @ConfigurationProperties("spring.datasource.write")
     public DataSourceProperties writeDataSourceProperties() {
         DataSourceProperties props = new DataSourceProperties();
-        System.out.println("### WRITE URL: " + props.getUrl());
         return props;
     }
 
     @Bean
     @ConfigurationProperties("spring.datasource.write.hikari")
-    public HikariDataSource writeDataSource() {
-        HikariDataSource ds =  writeDataSourceProperties()
+    public HikariDataSource writeDataSource(DataSourceProperties writeDataSourceProperties) {
+        HikariDataSource ds = writeDataSourceProperties
                 .initializeDataSourceBuilder()
                 .type(HikariDataSource.class)
                 .build();
@@ -40,8 +39,8 @@ public class DataSourceConfig {
 
     @Bean
     @ConfigurationProperties("spring.datasource.read.hikari")
-    public HikariDataSource readDataSource() {
-        HikariDataSource ds =  readDataSourceProperties()
+    public HikariDataSource readDataSource(DataSourceProperties readDataSourceProperties) {
+        HikariDataSource ds = readDataSourceProperties
                 .initializeDataSourceBuilder()
                 .type(HikariDataSource.class)
                 .build();
@@ -51,12 +50,10 @@ public class DataSourceConfig {
 
     @Bean
     @Primary
-    public DataSource dataSource() {
-        HikariDataSource write = writeDataSource();
-        HikariDataSource read = readDataSource();
+    public DataSource dataSource(HikariDataSource writeDataSource, HikariDataSource readDataSource) {
         var routing = new RoutingDataSource();
-        routing.setTargetDataSources(Map.of("write", write, "read", read));
-        routing.setDefaultTargetDataSource(write);
+        routing.setTargetDataSources(Map.of("write", writeDataSource, "read", readDataSource));
+        routing.setDefaultTargetDataSource(writeDataSource);
         return routing;
     }
 }

--- a/src/main/java/com/payflow/infrastructure/kafka/consumer/AnalyticsConsumer.java
+++ b/src/main/java/com/payflow/infrastructure/kafka/consumer/AnalyticsConsumer.java
@@ -2,7 +2,6 @@ package com.payflow.infrastructure.kafka.consumer;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,7 +13,8 @@ public class AnalyticsConsumer {
             topics = "${payflow.kafka.topics.transactions}",
             groupId = "${payflow.kafka.consumer.analytics-group}"
     )
-    public void handle(String payload, Acknowledgment ack) {
+    public void handle(String payload) {
         // write to TimescaleDB / analytics store
+        // TODO: add hypertable range query test when analytics endpoints are implemented
     }
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerReconciliationRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerReconciliationRepository.java
@@ -1,0 +1,20 @@
+package com.payflow.infrastructure.persistence.jpa;
+
+import com.payflow.domain.model.ledger.LedgerEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface LedgerReconciliationRepository extends JpaRepository<LedgerEntry, UUID> {
+
+    @Query(value = """
+    SELECT 
+        COALESCE(SUM(amount) FILTER (WHERE entry_type = 'CREDIT'), 0) -
+        COALESCE(SUM(amount) FILTER (WHERE entry_type = 'DEBIT'), 0)
+    FROM ledger_entries
+    """, nativeQuery = true)
+    long computeGlobalDelta();
+}

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/ReconciliationAlertJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/ReconciliationAlertJpaRepository.java
@@ -1,0 +1,10 @@
+package com.payflow.infrastructure.persistence.jpa;
+
+import com.payflow.domain.model.ReconciliationAlert;
+import com.payflow.domain.repository.ReconciliationAlertRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReconciliationAlertJpaRepository extends JpaRepository<ReconciliationAlert, UUID>, ReconciliationAlertRepository {
+}

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface TransactionJpaRepository extends JpaRepository<Transaction,UUID >, TransactionRepository {
+    @Override
+    Transaction save(Transaction transaction);
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletJpaRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface WalletJpaRepository extends JpaRepository<Wallet, UUID>, WalletRepository {
-    @Override
-    Wallet save(Wallet wallet);
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
@@ -13,19 +13,19 @@ import java.util.UUID;
 public interface WalletReconciliationRepository extends JpaRepository<Wallet, UUID> {
 
     @Query("""
-        SELECT new  com.payflow.infrastructure.reconciliation.WalletDiscrepancy(
+        SELECT new com.payflow.infrastructure.reconciliation.WalletDiscrepancy(
             w.id,
             w.currentBalance,
-            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.CREDIT THEN l.amount ELSE 0 END), 0) -
-            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.DEBIT THEN l.amount ELSE 0 END), 0)
+            COALESCE((
+                SELECT SUM(CASE WHEN l.entryType = com.payflow.domain.model.ledger.EntryType.CREDIT THEN l.amount ELSE -l.amount END)
+                FROM LedgerEntry l WHERE l.walletId = w.id
+            ), 0)
         )
         FROM Wallet w
-        LEFT JOIN LedgerEntry l ON l.walletId = w.id
-        GROUP BY w.id, w.currentBalance
-        HAVING w.currentBalance <> (
-            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.CREDIT THEN l.amount ELSE 0 END), 0) -
-            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.DEBIT THEN l.amount ELSE 0 END), 0)
-        )
+        WHERE w.currentBalance != COALESCE((
+            SELECT SUM(CASE WHEN l.entryType = com.payflow.domain.model.ledger.EntryType.CREDIT THEN l.amount ELSE -l.amount END)
+            FROM LedgerEntry l WHERE l.walletId = w.id
+        ), 0)
         """)
     List<WalletDiscrepancy> findCacheDiscrepancies();
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
@@ -16,15 +16,15 @@ public interface WalletReconciliationRepository extends JpaRepository<Wallet, UU
         SELECT new  com.payflow.infrastructure.reconciliation.WalletDiscrepancy(
             w.id,
             w.currentBalance,
-            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'CREDIT'), 0) -
-            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'DEBIT'),   0)
+            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.CREDIT THEN l.amount ELSE 0 END), 0) -
+            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.DEBIT THEN l.amount ELSE 0 END), 0)
         )
         FROM Wallet w
         LEFT JOIN LedgerEntry l ON l.walletId = w.id
         GROUP BY w.id, w.currentBalance
         HAVING w.currentBalance <> (
-            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'CREDIT'), 0) -
-            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'DEBIT'),   0)
+            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.CREDIT THEN l.amount ELSE 0 END), 0) -
+            COALESCE(SUM(CASE WHEN l.entryType = com.payflow.domain.model.wallet.EntryType.DEBIT THEN l.amount ELSE 0 END), 0)
         )
         """)
     List<WalletDiscrepancy> findCacheDiscrepancies();

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/WalletReconciliationRepository.java
@@ -1,0 +1,31 @@
+package com.payflow.infrastructure.persistence.jpa;
+
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.reconciliation.WalletDiscrepancy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface WalletReconciliationRepository extends JpaRepository<Wallet, UUID> {
+
+    @Query("""
+        SELECT new  com.payflow.infrastructure.reconciliation.WalletDiscrepancy(
+            w.id,
+            w.currentBalance,
+            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'CREDIT'), 0) -
+            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'DEBIT'),   0)
+        )
+        FROM Wallet w
+        LEFT JOIN LedgerEntry l ON l.walletId = w.id
+        GROUP BY w.id, w.currentBalance
+        HAVING w.currentBalance <> (
+            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'CREDIT'), 0) -
+            COALESCE(SUM(l.amount) FILTER (WHERE l.entryType = 'DEBIT'),   0)
+        )
+        """)
+    List<WalletDiscrepancy> findCacheDiscrepancies();
+}

--- a/src/main/java/com/payflow/infrastructure/reconciliation/ReconciliationAlertService.java
+++ b/src/main/java/com/payflow/infrastructure/reconciliation/ReconciliationAlertService.java
@@ -1,0 +1,39 @@
+package com.payflow.infrastructure.reconciliation;
+
+import com.payflow.domain.model.AlertType;
+import com.payflow.domain.model.ReconciliationAlert;
+import com.payflow.domain.repository.ReconciliationAlertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReconciliationAlertService {
+
+    private final ReconciliationAlertRepository alertRepository;
+
+    public void onGlobalImbalance(long delta) {
+        // Week 3: wire to email
+        log.error("[ALERT] Global ledger imbalance: delta={}", delta);
+        alertRepository.save(ReconciliationAlert.builder()
+                .type(AlertType.GLOBAL_IMBALANCE)
+                .detail("Global ledger delta: " + delta)
+                .build());
+    }
+
+    public void onWalletDiscrepancies(List<WalletDiscrepancy> discrepancies) {
+        // Week 3: wire to email
+        log.error("[ALERT] {} wallet cache discrepancies detected", discrepancies.size());
+        discrepancies.forEach(d ->
+                alertRepository.save(ReconciliationAlert.builder()
+                        .type(AlertType.WALLET_CACHE_DISCREPANCY)
+                        .detail("walletId=%s cached=%d computed=%d"
+                                .formatted(d.walletId(), d.cachedBalance(), d.computedBalance()))
+                        .build())
+        );
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/reconciliation/ReconciliationService.java
+++ b/src/main/java/com/payflow/infrastructure/reconciliation/ReconciliationService.java
@@ -1,0 +1,45 @@
+package com.payflow.infrastructure.reconciliation;
+
+import com.payflow.infrastructure.persistence.jpa.LedgerReconciliationRepository;
+import com.payflow.infrastructure.persistence.jpa.WalletReconciliationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReconciliationService {
+    private final LedgerReconciliationRepository ledgerRepo;
+    private final WalletReconciliationRepository walletRepo;
+    private final ReconciliationAlertService alertService;
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void reconcile()
+    {
+        checkGlobalBalance();
+        checkWalletCache();
+    }
+
+    private void checkGlobalBalance() {
+        long delta = ledgerRepo.computeGlobalDelta();
+        if(delta!=0)
+        {
+            log.error("[RECONCILIATION] Global ledger imbalance detected: delta={}", delta);
+            alertService.onGlobalImbalance(delta);
+        }
+    }
+
+    private void checkWalletCache() {
+        List<WalletDiscrepancy> discrepancies = walletRepo.findCacheDiscrepancies();
+        if(discrepancies.isEmpty()) return;
+        discrepancies.forEach(d ->
+                log.error("[RECONCILIATION] Wallet cache mismatch: walletId={} cached={} computed={}",
+                        d.walletId(), d.cachedBalance(), d.computedBalance())
+        );
+        alertService.onWalletDiscrepancies(discrepancies);
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/reconciliation/WalletDiscrepancy.java
+++ b/src/main/java/com/payflow/infrastructure/reconciliation/WalletDiscrepancy.java
@@ -1,0 +1,10 @@
+package com.payflow.infrastructure.reconciliation;
+
+import java.util.UUID;
+
+public record WalletDiscrepancy(
+        UUID walletId,
+        long  cachedBalance,
+        long  computedBalance
+) {
+}

--- a/src/main/java/com/payflow/infrastructure/security/TokenService.java
+++ b/src/main/java/com/payflow/infrastructure/security/TokenService.java
@@ -37,7 +37,12 @@ public class TokenService {
 
 
     protected SecretKey getSignInKey() {
-        byte[] decodedKey = Base64.getUrlDecoder().decode(jwtSecret);
+        byte[] decodedKey;
+        try {
+            decodedKey = Base64.getDecoder().decode(jwtSecret);
+        } catch (IllegalArgumentException ex) {
+            decodedKey = Base64.getUrlDecoder().decode(jwtSecret);
+        }
         return Keys.hmacShaKeyFor(decodedKey);
     }
 }

--- a/src/main/java/com/payflow/infrastructure/security/TokenService.java
+++ b/src/main/java/com/payflow/infrastructure/security/TokenService.java
@@ -37,7 +37,7 @@ public class TokenService {
 
 
     protected SecretKey getSignInKey() {
-        byte[] decodedKey = Base64.getDecoder().decode(jwtSecret);
+        byte[] decodedKey = Base64.getUrlDecoder().decode(jwtSecret);
         return Keys.hmacShaKeyFor(decodedKey);
     }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,4 @@
-yamlspring:
+spring:
   datasource:
     write:
       url:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,14 @@
+yamlspring:
+  datasource:
+    write:
+      url:
+      username:
+      password:
+    read:
+      url:
+      username:
+      password:
+app:
+  jwt:
+    secret: test-secret-key-that-is-long-enough-for-hs512-algorithm-probably-have-to-be-longer
+    expiration: 3600000

--- a/src/main/resources/db/migration/V17__enable_timescaledb.sql
+++ b/src/main/resources/db/migration/V17__enable_timescaledb.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;

--- a/src/main/resources/db/migration/V18__recreate_ledger_entries_hypertable.sql
+++ b/src/main/resources/db/migration/V18__recreate_ledger_entries_hypertable.sql
@@ -1,0 +1,18 @@
+DROP TABLE public.ledger_entries;
+
+CREATE TABLE ledger_entries
+(
+    id             UUID             DEFAULT gen_random_uuid() NOT NULL,
+    transaction_id UUID             NOT NULL REFERENCES transactions (id),
+    wallet_id      UUID             NOT NULL REFERENCES wallets (id),
+    entry_type     VARCHAR(10)      NOT NULL CHECK (entry_type IN ('DEBIT', 'CREDIT')),
+    amount         BIGINT           NOT NULL CHECK (amount > 0),
+    balance_after  BIGINT           NOT NULL,
+    created_at     TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, created_at)
+);
+
+CREATE INDEX idx_ledger_transaction ON ledger_entries (transaction_id);
+CREATE INDEX idx_ledger_wallet ON ledger_entries (wallet_id, created_at DESC);
+
+SELECT create_hypertable('ledger_entries', 'created_at', chunk_time_interval => INTERVAL '1 month');

--- a/src/main/resources/db/migration/V19__create_reconciliation_alerts.sql
+++ b/src/main/resources/db/migration/V19__create_reconciliation_alerts.sql
@@ -1,0 +1,7 @@
+CREATE TABLE reconciliation_alerts
+(
+    id          UUID        DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    type        VARCHAR(40)                           NOT NULL,
+    detail      TEXT                                  NOT NULL,
+    occurred_at TIMESTAMPTZ DEFAULT NOW()             NOT NULL
+);

--- a/src/main/resources/db/migration/V20__add_unique_constraint_ledger_id.sql
+++ b/src/main/resources/db/migration/V20__add_unique_constraint_ledger_id.sql
@@ -1,1 +1,0 @@
-ALTER TABLE ledger_entries ADD CONSTRAINT ledger_entries_id_unique UNIQUE (id);

--- a/src/main/resources/db/migration/V20__add_unique_constraint_ledger_id.sql
+++ b/src/main/resources/db/migration/V20__add_unique_constraint_ledger_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ledger_entries ADD CONSTRAINT ledger_entries_id_unique UNIQUE (id);

--- a/src/test/java/com/payflow/BaseIntegrationTest.java
+++ b/src/test/java/com/payflow/BaseIntegrationTest.java
@@ -19,7 +19,7 @@ public abstract class BaseIntegrationTest {
     static final PostgreSQLContainer postgres;
 
     static {
-        postgres = new PostgreSQLContainer(DockerImageName.parse("timescale/timescaledb:2.17.2-pg18")
+        postgres = new PostgreSQLContainer(DockerImageName.parse("timescale/timescaledb:latest-pg18")
                 .asCompatibleSubstituteFor("postgres")
         ).withDatabaseName("payflow");
         postgres.start();

--- a/src/test/java/com/payflow/BaseIntegrationTest.java
+++ b/src/test/java/com/payflow/BaseIntegrationTest.java
@@ -19,7 +19,7 @@ public abstract class BaseIntegrationTest {
     static final PostgreSQLContainer postgres;
 
     static {
-        postgres = new PostgreSQLContainer(DockerImageName.parse("timescale/timescaledb:latest-pg18")
+        postgres = new PostgreSQLContainer(DockerImageName.parse("timescale/timescaledb:2.17.2-pg18")
                 .asCompatibleSubstituteFor("postgres")
         ).withDatabaseName("payflow");
         postgres.start();

--- a/src/test/java/com/payflow/BaseIntegrationTest.java
+++ b/src/test/java/com/payflow/BaseIntegrationTest.java
@@ -3,12 +3,15 @@ package com.payflow;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)
 @AutoConfigureRestTestClient
 public abstract class BaseIntegrationTest {
@@ -16,8 +19,9 @@ public abstract class BaseIntegrationTest {
     static final PostgreSQLContainer postgres;
 
     static {
-        postgres = new PostgreSQLContainer("postgres:18-alpine")
-                .withDatabaseName("payflow");
+        postgres = new PostgreSQLContainer(DockerImageName.parse("timescale/timescaledb:latest-pg18")
+                .asCompatibleSubstituteFor("postgres")
+        ).withDatabaseName("payflow");
         postgres.start();
     }
 

--- a/src/test/java/com/payflow/PayflowApplicationTests.java
+++ b/src/test/java/com/payflow/PayflowApplicationTests.java
@@ -3,15 +3,13 @@ package com.payflow;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
         properties = {"spring.kafka.admin.fail-fast=false"},
         webEnvironment = SpringBootTest.WebEnvironment.NONE
 )
 @Import(TestcontainersConfiguration.class)
-@ActiveProfiles("test")
-class PayflowApplicationTests extends BaseIntegrationTest{
+class PayflowApplicationTests {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/payflow/PayflowApplicationTests.java
+++ b/src/test/java/com/payflow/PayflowApplicationTests.java
@@ -3,12 +3,14 @@ package com.payflow;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
         properties = {"spring.kafka.admin.fail-fast=false"},
         webEnvironment = SpringBootTest.WebEnvironment.NONE
 )
 @Import(TestcontainersConfiguration.class)
+@ActiveProfiles("test")
 class PayflowApplicationTests {
 
     @Test

--- a/src/test/java/com/payflow/PayflowApplicationTests.java
+++ b/src/test/java/com/payflow/PayflowApplicationTests.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 )
 @Import(TestcontainersConfiguration.class)
 @ActiveProfiles("test")
-class PayflowApplicationTests {
+class PayflowApplicationTests extends BaseIntegrationTest{
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -38,6 +38,9 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
     @Autowired
     private UserJpaRepository userRepository;
 
+    @Autowired
+    private com.payflow.infrastructure.persistence.jpa.TransactionJpaRepository transactionRepository;
+
     @BeforeEach
     void setUp() {
         User user = User.builder()
@@ -54,10 +57,11 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        transactionRepository.deleteAll();
         walletRepository.deleteAll();
         userRepository.deleteAll();
         cacheManager.getCache("wallets").clear();
-}
+    }
 
 
     @Test

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -4,6 +4,8 @@ import com.payflow.BaseIntegrationTest;
 import com.payflow.application.service.WalletService;
 import com.payflow.domain.model.user.User;
 import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.infrastructure.persistence.jpa.LedgerEntryJpaRepository;
+import com.payflow.infrastructure.persistence.jpa.TransactionJpaRepository;
 import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
 import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
 import org.junit.jupiter.api.*;
@@ -39,7 +41,10 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
     private UserJpaRepository userRepository;
 
     @Autowired
-    private com.payflow.infrastructure.persistence.jpa.TransactionJpaRepository transactionRepository;
+    private TransactionJpaRepository transactionRepository;
+
+    @Autowired
+    private LedgerEntryJpaRepository ledgerEntryRepository;
 
     @BeforeEach
     void setUp() {
@@ -57,6 +62,7 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        ledgerEntryRepository.deleteAll();
         transactionRepository.deleteAll();
         walletRepository.deleteAll();
         userRepository.deleteAll();

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -10,7 +10,6 @@ import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
 import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -20,7 +19,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-class CacheIntegrationTest  extends BaseIntegrationTest {
+class CacheIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private WalletService walletService;
@@ -69,56 +68,43 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
         cacheManager.getCache("wallets").clear();
     }
 
-
     @Test
     void getActiveByIdFirstCallPopulatesCache() {
-        // Given
         transactionTemplate.execute(status -> {
             walletService.getActiveById(walletId, userId);
             return null;
         });
 
-        // When
-        Cache cache = cacheManager.getCache("wallets");
-
-        // Then
-        assertNotNull(cache.get(walletId + ":" + userId));
+        assertNotNull(cacheManager.getCache("wallets").get(walletId + ":" + userId));
     }
 
     @Test
     void getActiveByIdSecondCallReturnsCachedValue() {
-        // Given
         transactionTemplate.execute(status -> {
             walletService.getActiveById(walletId, userId);
             return null;
         });
 
-        // When
         Wallet first = walletService.getActiveById(walletId, userId);
         Wallet second = walletService.getActiveById(walletId, userId);
 
-        // Then
         assertEquals(first.getId(), second.getId());
     }
 
-
     @Test
     void saveEvictsCache() {
-        // Given — populate cache in committed transaction
         transactionTemplate.execute(status -> {
             walletService.getActiveById(walletId, userId);
             return null;
         });
         assertNotNull(cacheManager.getCache("wallets").get(walletId + ":" + userId));
 
-        // When — evict in committed transaction
         transactionTemplate.execute(status -> {
             Wallet wallet = walletService.getActiveById(walletId, userId);
             walletService.save(wallet);
             return null;
         });
 
-        // Then
         assertNull(cacheManager.getCache("wallets").get(walletId + ":" + userId));
     }
 }

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -41,7 +41,7 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
     @BeforeEach
     void setUp() {
         User user = User.builder()
-                .email("test@payflow.com")
+                .email("test-" + UUID.randomUUID() + "@payflow.com")
                 .fullName("Test User")
                 .passwordHash("test123").build();
         user = userRepository.save(user);

--- a/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/CacheIntegrationTest.java
@@ -10,13 +10,13 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Currency;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
 class CacheIntegrationTest  extends BaseIntegrationTest {
 
@@ -28,6 +28,9 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
 
     @Autowired
     private CacheManager cacheManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     private UUID walletId;
     private UUID userId;
@@ -54,13 +57,16 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
         walletRepository.deleteAll();
         userRepository.deleteAll();
         cacheManager.getCache("wallets").clear();
-    }
+}
 
 
     @Test
     void getActiveByIdFirstCallPopulatesCache() {
         // Given
-        walletService.getActiveById(walletId, userId);
+        transactionTemplate.execute(status -> {
+            walletService.getActiveById(walletId, userId);
+            return null;
+        });
 
         // When
         Cache cache = cacheManager.getCache("wallets");
@@ -72,6 +78,12 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
     @Test
     void getActiveByIdSecondCallReturnsCachedValue() {
         // Given
+        transactionTemplate.execute(status -> {
+            walletService.getActiveById(walletId, userId);
+            return null;
+        });
+
+        // When
         Wallet first = walletService.getActiveById(walletId, userId);
         Wallet second = walletService.getActiveById(walletId, userId);
 
@@ -82,17 +94,21 @@ class CacheIntegrationTest  extends BaseIntegrationTest {
 
     @Test
     void saveEvictsCache() {
-        // Given
-        walletService.getActiveById(walletId, userId);
-        assertNotNull(cacheManager.getCache("wallets")
-                .get(walletId + ":" + userId));
+        // Given — populate cache in committed transaction
+        transactionTemplate.execute(status -> {
+            walletService.getActiveById(walletId, userId);
+            return null;
+        });
+        assertNotNull(cacheManager.getCache("wallets").get(walletId + ":" + userId));
 
-        // When
-        Wallet wallet = walletService.getActiveById(walletId, userId);
-        walletService.save(wallet);
+        // When — evict in committed transaction
+        transactionTemplate.execute(status -> {
+            Wallet wallet = walletService.getActiveById(walletId, userId);
+            walletService.save(wallet);
+            return null;
+        });
 
         // Then
-        assertNull(cacheManager.getCache("wallets")
-                .get(walletId + ":" + userId));
+        assertNull(cacheManager.getCache("wallets").get(walletId + ":" + userId));
     }
 }

--- a/src/test/java/com/payflow/infrastructure/datasource/DataSourceRoutingIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/datasource/DataSourceRoutingIntegrationTest.java
@@ -14,7 +14,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.flyway.enabled=false", "spring.jpa.hibernate.ddl-auto=none"})
 @Testcontainers
 class DataSourceRoutingIntegrationTest {
 

--- a/src/test/java/com/payflow/infrastructure/reconciliation/ReconciliationServiceIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/reconciliation/ReconciliationServiceIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.payflow.infrastructure.reconciliation;
+
+import com.payflow.BaseIntegrationTest;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.AlertType;
+import com.payflow.domain.model.ReconciliationAlert;
+import com.payflow.domain.model.ledger.LedgerEntry;
+import com.payflow.domain.model.transaction.Transaction;
+import com.payflow.domain.model.transaction.TransactionType;
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.LedgerEntryRepository;
+import com.payflow.domain.repository.ReconciliationAlertRepository;
+import com.payflow.infrastructure.persistence.jpa.TransactionJpaRepository;
+import com.payflow.infrastructure.persistence.jpa.UserJpaRepository;
+import com.payflow.infrastructure.persistence.jpa.WalletJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Currency;
+import java.util.List;
+import java.util.UUID;
+
+import static com.payflow.domain.model.ledger.EntryType.CREDIT;
+import static com.payflow.domain.model.ledger.EntryType.DEBIT;
+import static org.assertj.core.api.Assertions.assertThat;
+class ReconciliationServiceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private ReconciliationService reconciliationService;
+    @Autowired private WalletJpaRepository walletRepository;
+    @Autowired private WalletService walletService;
+    @Autowired private LedgerEntryRepository ledgerEntryRepository;
+    @Autowired private ReconciliationAlertRepository alertRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private UserJpaRepository userRepository;
+    @Autowired private TransactionJpaRepository transactionRepository;
+
+    private User testUser;
+    private Wallet testWallet;
+    private Transaction testTransaction;
+
+
+
+    @BeforeEach
+    void setUp() {
+        alertRepository.deleteAll();
+        ledgerEntryRepository.deleteAll();
+        transactionRepository.deleteAll();
+        walletRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = userRepository.save(User.builder()
+                .fullName("Test User")
+                .email("test@payflow.com")
+                .passwordHash("hashedpassword")
+                .build());
+
+        testWallet = walletService.save(Wallet.create(
+                testUser.getId(),
+                Currency.getInstance("GBP")
+        ));
+
+        testTransaction = transactionRepository.save(Transaction.create(
+                UUID.randomUUID().toString(),
+                TransactionType.DEPOSIT,
+                null,
+                testWallet.getId(),
+                1000L,
+                Currency.getInstance("GBP"),
+                testUser.getId()
+        ));
+    }
+
+    private LedgerEntry creditEntryWith1000(long balanceAfter) {
+        return LedgerEntry.builder()
+                .transactionId(testTransaction.getId())
+                .walletId(testWallet.getId())
+                .amount(1000L)
+                .entryType(CREDIT)
+                .balanceAfter(balanceAfter)
+                .build();
+    }
+
+    private LedgerEntry debitEntryWith(long amount,long balanceAfter) {
+        return LedgerEntry.builder()
+                .transactionId(testTransaction.getId())
+                .walletId(testWallet.getId())
+                .amount(amount)
+                .entryType(DEBIT)
+                .balanceAfter(balanceAfter)
+                .build();
+    }
+
+    @Test
+    void reconcileShouldNotCreateAlertWhenLedgerIsBalanced() {
+        // Given — CREDIT 1000, DEBIT 1000, delta = 0
+        ledgerEntryRepository.save(creditEntryWith1000(1000L));
+        ledgerEntryRepository.save(debitEntryWith(1000L,0L));
+
+        // When
+        reconciliationService.reconcile();
+
+        // Then
+        assertThat(alertRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void reconcileShouldCreateAlertOnGlobalImbalance() {
+        // Given — CREDIT 1000, DEBIT 500, delta = 500 (global imbalance)
+        // wallet cache set to 500 to avoid triggering cache discrepancy too
+        ledgerEntryRepository.save(creditEntryWith1000(1000L));
+        ledgerEntryRepository.save(debitEntryWith(500L,500L));
+        jdbcTemplate.update("UPDATE wallets SET current_balance = ? WHERE id = ?", 500L, testWallet.getId());
+
+        // When
+        reconciliationService.reconcile();
+
+        // Then
+        List<ReconciliationAlert> alerts = alertRepository.findAll();
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.getFirst().getType()).isEqualTo(AlertType.GLOBAL_IMBALANCE);
+    }
+
+    @Test
+    void reconcileShouldCreateAlertOnWalletCacheDiscrepancy() {
+        // Given — ledger is globally balanced (1000 CREDIT, 1000 DEBIT)
+        // but wallet cache says 800 instead of the correct 1000 net
+        ledgerEntryRepository.save(creditEntryWith1000(1000L));
+        ledgerEntryRepository.save(
+                debitEntryWith(1000L,1000L)
+        );
+        jdbcTemplate.update("UPDATE wallets SET current_balance = ? WHERE id = ?", 800L, testWallet.getId());
+
+        // When
+        reconciliationService.reconcile();
+
+        // Then
+        List<ReconciliationAlert> alerts = alertRepository.findAll();
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.getFirst().getType()).isEqualTo(AlertType.WALLET_CACHE_DISCREPANCY);
+        assertThat(alerts.getFirst().getDetail()).contains(testWallet.getId().toString());
+    }
+}


### PR DESCRIPTION
## What
Migrates `ledger_entries` to a TimescaleDB hypertable and introduces a scheduled reconciliation service that detects global ledger imbalances and wallet cached-balance discrepancies, persisting each finding as a `ReconciliationAlert`.

## Linked Issue
Closes #51

## Why
The ledger is the source of truth for all money movement. Without automated reconciliation, silent drift between the cached wallet balance and the ledger sum would go undetected until a user-facing failure. TimescaleDB provides time-series partitioning on `ledger_entries`, keeping range queries performant as the table grows — a prerequisite for the scheduled reconciliation queries that scan the full ledger.

## Changes
**Domain**
- `AlertType` enum (`GLOBAL_IMBALANCE`, `WALLET_CACHE_DISCREPANCY`)
- `ReconciliationAlert` aggregate, `ReconciliationAlertRepository` domain interface
- `deleteAll()` added to `LedgerEntryRepository` and `WalletRepository` (test teardown)

**Persistence**
- `LedgerReconciliationRepository` — JPQL query summing all debit/credit entries for global balance check
- `WalletReconciliationRepository` — per-wallet ledger sum vs cached balance comparison
- `ReconciliationAlertJpaRepository` — Spring Data impl for alerts
- `V17` enables TimescaleDB extension; `V18` recreates `ledger_entries` as a hypertable; `V19` creates `reconciliation_alerts` table

**Infrastructure**
- `ReconciliationService` — `@Scheduled` job running both checks and delegating to `ReconciliationAlertService`
- `ReconciliationAlertService` — persists alerts via domain repository
- `WalletDiscrepancy` value object carrying wallet ID + delta
- `@EnableScheduling` added to `PayflowApplication`
- Docker Compose images updated from `postgres:18-alpine` → `timescale/timescaledb:latest-pg18`
- `DataSourceConfig` refactored to inject `DataSourceProperties` beans explicitly (fixes self-invocation proxy bypass)

**Tests**
- `ReconciliationServiceIntegrationTest` — full integration test covering: no alerts on clean ledger, `GLOBAL_IMBALANCE` alert on unbalanced entries, `WALLET_CACHE_DISCREPANCY` alert when cached balance diverges from ledger sum

## Testing
- `ReconciliationServiceIntegrationTest` uses Testcontainers (TimescaleDB image) — no H2
- Covers: clean-state baseline, injected global imbalance, injected per-wallet cache drift