### PR TITLE
Add idempotency and concurrency integration tests for deposit, transfer, and withdrawal

### DIFF
--- a/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
+++ b/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public interface LedgerEntryRepository {
     LedgerEntry save(LedgerEntry ledgerEntry);
-    List<LedgerEntry> findAllByTransactionId(UUID walletId);
+    List<LedgerEntry> findAllByTransactionId(UUID transactionId);
     void deleteAll();
 }

--- a/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
+++ b/src/main/java/com/payflow/domain/repository/LedgerEntryRepository.java
@@ -2,7 +2,11 @@ package com.payflow.domain.repository;
 
 import com.payflow.domain.model.ledger.LedgerEntry;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface LedgerEntryRepository {
     LedgerEntry save(LedgerEntry ledgerEntry);
+    List<LedgerEntry> findAllByTransactionId(UUID walletId);
     void deleteAll();
 }

--- a/src/main/java/com/payflow/domain/repository/WalletRepository.java
+++ b/src/main/java/com/payflow/domain/repository/WalletRepository.java
@@ -15,6 +15,7 @@ public interface WalletRepository {
     List<Wallet> findAllByUserId(UUID userId);
     Optional<Wallet> findByIdAndUserIdAndStatus(UUID id, UUID userId, WalletStatus status);
     Optional<Wallet> findByIdAndStatus(UUID id, WalletStatus status);
+    Optional<Wallet> findById(UUID id);
     Wallet save(Wallet wallet);
     void deleteAll();
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntry, UUID>, LedgerEntryRepository {
+
 }

--- a/src/test/java/com/payflow/application/command/transactions/DepositCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/DepositCommandHandlerTest.java
@@ -8,7 +8,6 @@ import com.payflow.domain.model.transaction.TransactionStatus;
 import com.payflow.domain.model.transaction.TransactionType;
 import com.payflow.domain.model.wallet.Wallet;
 import com.payflow.domain.repository.TransactionRepository;
-import com.payflow.domain.repository.WalletRepository;
 import com.payflow.infrastructure.kafka.TransactionOutboxWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,9 +31,6 @@ class DepositCommandHandlerTest {
 
     @Mock
     private IdempotencyService idempotencyService;
-
-    @Mock
-    private WalletRepository walletRepository;
 
     @Mock
     private TransactionRepository transactionRepository;

--- a/src/test/java/com/payflow/application/command/transactions/DepositIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/DepositIdempotencyIntegrationTest.java
@@ -21,13 +21,13 @@ class DepositIdempotencyIntegrationTest extends BaseTransactionTest {
     @Autowired WalletRepository walletRepository;
     @Autowired DepositCommandHandler depositHandler;
 
-    private static final String IDEMPOTENCY_KEY = "idem-deposit-" + UUID.randomUUID();
-
     @Test
     void duplicateDepositWithSameKeyProducesExactlyOneTransactionAndOneLedgerEntry() {
         // Given
+        String idempotencyKey =  "idem-deposit-" + UUID.randomUUID();
+
         DepositCommandHandler.Command command = new DepositCommandHandler.Command(
-                IDEMPOTENCY_KEY, wallet.getId(), user.getId(), 5_000L
+                idempotencyKey, wallet.getId(), user.getId(), 5_000L
         );
 
         // When
@@ -37,7 +37,7 @@ class DepositIdempotencyIntegrationTest extends BaseTransactionTest {
         // Then
         assertThat(second.getId()).isEqualTo(first.getId());
 
-        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+        assertThat(transactionRepository.findByIdempotencyKey(idempotencyKey))
                 .isPresent()
                 .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
 

--- a/src/test/java/com/payflow/application/command/transactions/DepositIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/DepositIdempotencyIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.payflow.application.command.transactions;
+
+
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.LedgerEntryRepository;
+import com.payflow.domain.repository.TransactionRepository;
+import com.payflow.domain.repository.WalletRepository;
+import com.payflow.infrastructure.BaseTransactionTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class DepositIdempotencyIntegrationTest extends BaseTransactionTest {
+
+    @Autowired TransactionRepository transactionRepository;
+    @Autowired LedgerEntryRepository ledgerRepository;
+    @Autowired WalletRepository walletRepository;
+    @Autowired DepositCommandHandler depositHandler;
+
+    private static final String IDEMPOTENCY_KEY = "idem-deposit-" + UUID.randomUUID();
+
+    @Test
+    void duplicateDepositWithSameKeyProducesExactlyOneTransactionAndOneLedgerEntry() {
+        // Given
+        DepositCommandHandler.Command command = new DepositCommandHandler.Command(
+                IDEMPOTENCY_KEY, wallet.getId(), user.getId(), 5_000L
+        );
+
+        // When
+        var first = depositHandler.handle(command);
+        var second = depositHandler.handle(command);
+
+        // Then
+        assertThat(second.getId()).isEqualTo(first.getId());
+
+        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+                .isPresent()
+                .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
+
+        assertThat(ledgerRepository.findAllByTransactionId(first.getId())).hasSize(1);
+
+        Wallet current = walletRepository.findById(wallet.getId()).orElseThrow();
+        assertThat(current.getCurrentBalance()).isEqualTo(5_000L);
+    }
+}

--- a/src/test/java/com/payflow/application/command/transactions/TransferIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/TransferIdempotencyIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.payflow.application.command.transactions;
+
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.LedgerEntryRepository;
+import com.payflow.domain.repository.TransactionRepository;
+import com.payflow.domain.repository.UserRepository;
+import com.payflow.domain.repository.WalletRepository;
+import com.payflow.infrastructure.BaseTransactionTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransferIdempotencyIntegrationTest extends BaseTransactionTest {
+
+    @Autowired TransferCommandHandler transferHandler;
+    @Autowired TransactionRepository transactionRepository;
+    @Autowired LedgerEntryRepository ledgerEntryRepository;
+    @Autowired WalletRepository walletRepository;
+    @Autowired WalletService walletService;
+    @Autowired UserRepository userRepository;
+
+    private static final String IDEMPOTENCY_KEY = "idem-transfer-" + UUID.randomUUID();
+
+    private User receiver;
+    private Wallet destinationWallet;
+
+    @BeforeEach
+    void setupSecondWallet() {
+        receiver = userRepository.save(
+                User.builder()
+                        .fullName("Receiver")
+                        .email("receiver-" + UUID.randomUUID() + "@payflow.com")
+                        .passwordHash("some-hash")
+                        .build()
+        );
+        destinationWallet = walletService.save(
+                Wallet.create(receiver.getId(), Currency.getInstance("GBP"))
+        );
+        seedBalance(10_000L);
+    }
+
+    @Test
+    void duplicateTransferWithSameKeyProducesExactlyOneTransactionAndTwoLedgerEntries() {
+        // Given
+        TransferCommandHandler.Command command = new TransferCommandHandler.Command(
+                IDEMPOTENCY_KEY, wallet.getId(), destinationWallet.getId(),
+                user.getId(), 4_000L
+        );
+
+        // When
+        var first = transferHandler.handle(command);
+        var second = transferHandler.handle(command);
+
+        // Then
+        assertThat(second.getId()).isEqualTo(first.getId());
+
+        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+                .isPresent()
+                .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
+
+        assertThat(ledgerEntryRepository.findAllByTransactionId(first.getId())).hasSize(2);
+
+        Wallet currentSource = walletRepository.findById(wallet.getId()).orElseThrow();
+        Wallet currentDestination = walletRepository.findById(destinationWallet.getId()).orElseThrow();
+        assertThat(currentSource.getCurrentBalance()).isEqualTo(6_000L);
+        assertThat(currentDestination.getCurrentBalance()).isEqualTo(4_000L);
+    }
+}

--- a/src/test/java/com/payflow/application/command/transactions/TransferIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/TransferIdempotencyIntegrationTest.java
@@ -26,14 +26,12 @@ class TransferIdempotencyIntegrationTest extends BaseTransactionTest {
     @Autowired WalletService walletService;
     @Autowired UserRepository userRepository;
 
-    private static final String IDEMPOTENCY_KEY = "idem-transfer-" + UUID.randomUUID();
 
-    private User receiver;
     private Wallet destinationWallet;
 
     @BeforeEach
     void setupSecondWallet() {
-        receiver = userRepository.save(
+        User receiver = userRepository.save(
                 User.builder()
                         .fullName("Receiver")
                         .email("receiver-" + UUID.randomUUID() + "@payflow.com")
@@ -49,8 +47,10 @@ class TransferIdempotencyIntegrationTest extends BaseTransactionTest {
     @Test
     void duplicateTransferWithSameKeyProducesExactlyOneTransactionAndTwoLedgerEntries() {
         // Given
+        String idempotencyKey =  "idem-transfer-" + UUID.randomUUID();
+
         TransferCommandHandler.Command command = new TransferCommandHandler.Command(
-                IDEMPOTENCY_KEY, wallet.getId(), destinationWallet.getId(),
+                idempotencyKey, wallet.getId(), destinationWallet.getId(),
                 user.getId(), 4_000L
         );
 
@@ -61,7 +61,7 @@ class TransferIdempotencyIntegrationTest extends BaseTransactionTest {
         // Then
         assertThat(second.getId()).isEqualTo(first.getId());
 
-        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+        assertThat(transactionRepository.findByIdempotencyKey(idempotencyKey))
                 .isPresent()
                 .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
 

--- a/src/test/java/com/payflow/application/command/transactions/WithdrawIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/WithdrawIdempotencyIntegrationTest.java
@@ -15,20 +15,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WithdrawIdempotencyIntegrationTest extends BaseTransactionTest {
 
     @Autowired WithdrawCommandHandler withdrawHandler;
-    @Autowired DepositCommandHandler depositHandler;
     @Autowired TransactionRepository transactionRepository;
     @Autowired LedgerEntryRepository ledgerRepository;
     @Autowired WalletService walletService;
-
-    private static final String IDEMPOTENCY_KEY = "idem-withdraw-" + UUID.randomUUID();
 
 
     @Test
     void duplicateWithdrawWithSameKeyProducesExactlyOneTransactionAndOneLedgerEntry() {
         // Given
         seedBalance(10_000L);
+        String idempotencyKey =  "idem-withdraw-" + UUID.randomUUID();
         WithdrawCommandHandler.Command command = new WithdrawCommandHandler.Command(
-                IDEMPOTENCY_KEY, wallet.getId(), user.getId(), 3_000L
+                idempotencyKey, wallet.getId(), user.getId(), 3_000L
         );
 
         // When
@@ -38,7 +36,7 @@ class WithdrawIdempotencyIntegrationTest extends BaseTransactionTest {
         // Then
         assertThat(second.getId()).isEqualTo(first.getId());
 
-        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+        assertThat(transactionRepository.findByIdempotencyKey(idempotencyKey))
                 .isPresent()
                 .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
 

--- a/src/test/java/com/payflow/application/command/transactions/WithdrawIdempotencyIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/transactions/WithdrawIdempotencyIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.payflow.application.command.transactions;
+
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.LedgerEntryRepository;
+import com.payflow.domain.repository.TransactionRepository;
+import com.payflow.infrastructure.BaseTransactionTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class WithdrawIdempotencyIntegrationTest extends BaseTransactionTest {
+
+    @Autowired WithdrawCommandHandler withdrawHandler;
+    @Autowired DepositCommandHandler depositHandler;
+    @Autowired TransactionRepository transactionRepository;
+    @Autowired LedgerEntryRepository ledgerRepository;
+    @Autowired WalletService walletService;
+
+    private static final String IDEMPOTENCY_KEY = "idem-withdraw-" + UUID.randomUUID();
+
+
+    @Test
+    void duplicateWithdrawWithSameKeyProducesExactlyOneTransactionAndOneLedgerEntry() {
+        // Given
+        seedBalance(10_000L);
+        WithdrawCommandHandler.Command command = new WithdrawCommandHandler.Command(
+                IDEMPOTENCY_KEY, wallet.getId(), user.getId(), 3_000L
+        );
+
+        // When
+        var first = withdrawHandler.handle(command);
+        var second = withdrawHandler.handle(command);
+
+        // Then
+        assertThat(second.getId()).isEqualTo(first.getId());
+
+        assertThat(transactionRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+                .isPresent()
+                .hasValueSatisfying(tx -> assertThat(tx.getId()).isEqualTo(first.getId()));
+
+
+        var ledgerEntries = ledgerRepository.findAllByTransactionId(first.getId());
+        assertThat(ledgerEntries).hasSize(1);
+
+        Wallet current = walletService.getActiveById(wallet.getId(), user.getId());
+        assertThat(current.getCurrentBalance()).isEqualTo(7_000L);
+    }
+}

--- a/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
@@ -1,0 +1,193 @@
+package com.payflow.application.command.wallet;
+
+import com.payflow.application.command.transactions.DepositCommandHandler;
+import com.payflow.application.command.transactions.TransferCommandHandler;
+import com.payflow.application.command.transactions.WithdrawCommandHandler;
+import com.payflow.domain.model.wallet.InsufficientBalanceException;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.WalletRepository;
+import com.payflow.infrastructure.BaseTransactionTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionConcurrencyTest extends BaseTransactionTest {
+    @Autowired
+    DepositCommandHandler depositHandler;
+    @Autowired
+    WithdrawCommandHandler withdrawHandler;
+    @Autowired
+    TransferCommandHandler transferHandler;
+    @Autowired
+    WalletRepository walletRepository;
+
+    private record ConcurrencyHarness(CountDownLatch ready,
+                                      CountDownLatch start) {
+        ConcurrencyHarness(int threadCount) {
+            this(new CountDownLatch(threadCount), new CountDownLatch(1));
+        }
+    }
+
+    private static final int THREAD_COUNT = 10;
+
+    private ExecutorService executor(){ return Executors.newFixedThreadPool(THREAD_COUNT);}
+    private ConcurrencyHarness harness() { return new ConcurrencyHarness(THREAD_COUNT);}
+
+    private void awaitAndFire(ConcurrencyHarness harness,
+                              ExecutorService executor) throws InterruptedException {
+        harness.ready.await();
+        harness.start.countDown();
+        executor.shutdown();
+        boolean finished = executor.awaitTermination(30, TimeUnit.SECONDS);
+        assertThat(finished).as("threads did not finish within timeout — possible deadlock").isTrue();
+    }
+
+
+    @Test
+    void concurrentDepositsOnSameWalletProduceConsistentBalance() throws InterruptedException {
+        // Given
+        long depositAmount = 1_000L;
+        List<Long> successful = new CopyOnWriteArrayList<>();
+        ExecutorService exec = executor();
+        ConcurrencyHarness h = harness();
+
+        // When
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            exec.submit(() -> {
+                try {
+                    h.ready.countDown();
+                    h.start.await();
+                    depositHandler.handle(new DepositCommandHandler.Command(
+                            UUID.randomUUID().toString(), wallet.getId(), user.getId(), depositAmount
+                    ));
+                    successful.add(depositAmount);
+                } catch (ObjectOptimisticLockingFailureException |
+                         PessimisticLockingFailureException _) {
+                    // exhausted retries — expected under contention
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        awaitAndFire(h, exec);
+
+        // Then
+        Wallet current = walletRepository.findById(wallet.getId()).orElseThrow();
+        assertThat(current.getCurrentBalance())
+                .isEqualTo(successful.stream().mapToLong(Long::longValue).sum());
+    }
+
+    @Test
+    void concurrentMixedDepositsAndWithdrawalsNeverCorruptBalance() throws InterruptedException {
+        // Given
+        long initialBalance = 10_000L;
+        seedBalance(initialBalance);
+
+        long depositAmount = 1_000L;
+        long withdrawAmount = 500L;
+        List<Long> successfulDeposits = new CopyOnWriteArrayList<>();
+        List<Long> successfulWithdrawals = new CopyOnWriteArrayList<>();
+        ExecutorService exec = executor();
+        ConcurrencyHarness h = harness();
+
+        // When
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            boolean isDeposit = i % 2 == 0;
+            exec.submit(() -> {
+                try {
+                    h.ready.countDown();
+                    h.start.await();
+                    String key = UUID.randomUUID().toString();
+                    if (isDeposit) {
+                        depositHandler.handle(new DepositCommandHandler.Command(
+                                key, wallet.getId(), user.getId(), depositAmount
+                        ));
+                        successfulDeposits.add(depositAmount);
+                    } else {
+                        withdrawHandler.handle(new WithdrawCommandHandler.Command(
+                                key, wallet.getId(), user.getId(), withdrawAmount
+                        ));
+                        successfulWithdrawals.add(withdrawAmount);
+                    }
+                } catch (ObjectOptimisticLockingFailureException |
+                         PessimisticLockingFailureException _) {
+                    // exhausted retries — expected under contention
+                } catch (InsufficientBalanceException _) {
+                    // valid business rejection — not corruption
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        awaitAndFire(h, exec);
+
+        // Then
+        long expectedBalance = initialBalance
+                + successfulDeposits.stream().mapToLong(Long::longValue).sum()
+                - successfulWithdrawals.stream().mapToLong(Long::longValue).sum();
+
+        Wallet current = walletRepository.findById(wallet.getId()).orElseThrow();
+        assertThat(current.getCurrentBalance())
+                .isGreaterThanOrEqualTo(0L)
+                .isEqualTo(expectedBalance);
+    }
+
+    @Test
+    void concurrentTransfersConserveMoneyAcrossBothWallets() throws InterruptedException {
+        // Given
+        long initialBalance = 10_000L;
+        seedBalance(initialBalance);
+        Wallet destination = freshWallet();
+
+        long transferAmount = 500L;
+        List<Long> successfulTransfers = new CopyOnWriteArrayList<>();
+        ExecutorService exec = executor();
+        ConcurrencyHarness h = harness();
+
+        // When
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            exec.submit(() -> {
+                try {
+                    h.ready.countDown();
+                    h.start.await();
+                    transferHandler.handle(new TransferCommandHandler.Command(
+                            UUID.randomUUID().toString(),
+                            wallet.getId(),
+                            destination.getId(),
+                            user.getId(),
+                            transferAmount
+                    ));
+                    successfulTransfers.add(transferAmount);
+                } catch (ObjectOptimisticLockingFailureException |
+                         PessimisticLockingFailureException _) {
+                    // exhausted retries — expected under contention
+                } catch (InsufficientBalanceException _) {
+                    // valid business rejection — not corruption
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        awaitAndFire(h, exec);
+
+        // Then
+        long totalTransferred = successfulTransfers.stream().mapToLong(Long::longValue).sum();
+        Wallet currentSource = walletRepository.findById(wallet.getId()).orElseThrow();
+        Wallet currentDestination = walletRepository.findById(destination.getId()).orElseThrow();
+
+        assertThat(currentSource.getCurrentBalance()).isGreaterThanOrEqualTo(0L);
+        assertThat(currentDestination.getCurrentBalance()).isEqualTo(totalTransferred);
+        assertThat(currentSource.getCurrentBalance() + currentDestination.getCurrentBalance())
+                .isEqualTo(initialBalance);
+    }
+}

--- a/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
@@ -42,8 +42,8 @@ class TransactionConcurrencyTest extends BaseTransactionTest {
 
     private void awaitAndFire(ConcurrencyHarness harness,
                               ExecutorService executor) throws InterruptedException {
-        harness.ready.await();
-        harness.start.countDown();
+        boolean ready = harness.ready.await(30, TimeUnit.SECONDS);
+        assertThat(ready).as("threads did not become ready within timeout").isTrue();
         executor.shutdown();
         boolean finished = executor.awaitTermination(30, TimeUnit.SECONDS);
         assertThat(finished).as("threads did not finish within timeout — possible deadlock").isTrue();
@@ -80,7 +80,12 @@ class TransactionConcurrencyTest extends BaseTransactionTest {
         awaitAndFire(h, exec);
 
         // Then
+        assertThat(successful)
+                .as("at least one deposit must succeed")
+                .isNotEmpty();
+
         Wallet current = walletRepository.findById(wallet.getId()).orElseThrow();
+
         assertThat(current.getCurrentBalance())
                 .isEqualTo(successful.stream().mapToLong(Long::longValue).sum());
     }
@@ -131,10 +136,14 @@ class TransactionConcurrencyTest extends BaseTransactionTest {
         awaitAndFire(h, exec);
 
         // Then
+        assertThat(successfulDeposits.size() + successfulWithdrawals.size())
+                .as("at least one operation must succeed for the test to be meaningful")
+                .isGreaterThan(0);
         long expectedBalance = initialBalance
                 + successfulDeposits.stream().mapToLong(Long::longValue).sum()
                 - successfulWithdrawals.stream().mapToLong(Long::longValue).sum();
 
+        assertThat(successfulDeposits).as("at least one deposit must succeed").isNotEmpty();
         Wallet current = walletRepository.findById(wallet.getId()).orElseThrow();
         assertThat(current.getCurrentBalance())
                 .isGreaterThanOrEqualTo(0L)
@@ -181,6 +190,8 @@ class TransactionConcurrencyTest extends BaseTransactionTest {
         awaitAndFire(h, exec);
 
         // Then
+        assertThat(successfulTransfers).as("at least one transfer must succeed for the test to be meaningful").isNotEmpty();
+
         long totalTransferred = successfulTransfers.stream().mapToLong(Long::longValue).sum();
         Wallet currentSource = walletRepository.findById(wallet.getId()).orElseThrow();
         Wallet currentDestination = walletRepository.findById(destination.getId()).orElseThrow();

--- a/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/TransactionConcurrencyTest.java
@@ -44,8 +44,9 @@ class TransactionConcurrencyTest extends BaseTransactionTest {
                               ExecutorService executor) throws InterruptedException {
         boolean ready = harness.ready.await(30, TimeUnit.SECONDS);
         assertThat(ready).as("threads did not become ready within timeout").isTrue();
+        harness.start.countDown();
         executor.shutdown();
-        boolean finished = executor.awaitTermination(30, TimeUnit.SECONDS);
+        boolean finished = executor.awaitTermination(60, TimeUnit.SECONDS);
         assertThat(finished).as("threads did not finish within timeout — possible deadlock").isTrue();
     }
 

--- a/src/test/java/com/payflow/infrastructure/BaseTransactionTest.java
+++ b/src/test/java/com/payflow/infrastructure/BaseTransactionTest.java
@@ -1,0 +1,54 @@
+package com.payflow.infrastructure;
+
+import com.payflow.BaseIntegrationTest;
+import com.payflow.application.command.transactions.DepositCommandHandler;
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Currency;
+import java.util.UUID;
+
+public abstract class BaseTransactionTest extends BaseIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    WalletService walletService;
+    @Autowired
+    DepositCommandHandler depositHandler;
+
+    protected User user;
+    protected Wallet wallet;
+
+    @BeforeEach
+    void setupUserAndWallet() {
+        user = userRepository.save(
+                User.builder()
+                        .fullName("Test User")
+                        .email("user-" + UUID.randomUUID() + "@payflow.com")
+                        .passwordHash("some-hash")
+                        .build()
+        );
+        wallet = walletService.save(Wallet.create(user.getId(), Currency.getInstance("GBP")));
+    }
+
+    protected void seedBalance(long amountCents) {
+        depositHandler.handle(new DepositCommandHandler.Command(
+                UUID.randomUUID().toString(), wallet.getId(), user.getId(), amountCents
+        ));
+    }
+    public Wallet freshWallet() {
+        User receiver = userRepository.save(
+                User.builder()
+                        .fullName("Receiver")
+                        .email("receiver-" + UUID.randomUUID() + "@payflow.com")
+                        .passwordHash("some-hash")
+                        .build()
+        );
+        return walletService.save(Wallet.create(receiver.getId(), Currency.getInstance("GBP")));
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/BaseTransactionTest.java
+++ b/src/test/java/com/payflow/infrastructure/BaseTransactionTest.java
@@ -41,7 +41,7 @@ public abstract class BaseTransactionTest extends BaseIntegrationTest {
                 UUID.randomUUID().toString(), wallet.getId(), user.getId(), amountCents
         ));
     }
-    public Wallet freshWallet() {
+    protected Wallet freshWallet() {
         User receiver = userRepository.save(
                 User.builder()
                         .fullName("Receiver")


### PR DESCRIPTION
## What
Adds integration tests that prove the Idempotent Consumer guarantee and SERIALIZABLE isolation hold under real concurrent load for deposit, transfer, and withdrawal operations.

## Linked Issue
Closes #53

## Why
The command handlers rely on idempotency key checks and SERIALIZABLE isolation to prevent double-credits and double-debits. These tests exercise those guarantees against a real PostgreSQL container using Testcontainers — not H2 — so any regression in locking or idempotency logic surfaces immediately.

## Changes
- **domain** — added `LedgerEntryRepository#findAllByTransactionId` and `WalletRepository#findById` to support assertion queries
- **test infra** — `BaseTransactionTest` extracts shared user/wallet setup, `seedBalance()`, and `freshWallet()` helpers
- **idempotency tests** — `DepositIdempotencyIntegrationTest`, `TransferIdempotencyIntegrationTest`, `WithdrawIdempotencyIntegrationTest` each submit the same command twice and assert exactly one transaction, correct ledger entry count, and correct final balance
- **concurrency tests** — `TransactionConcurrencyTest` fires 10 concurrent threads for deposits-only, mixed deposit/withdrawal, and transfer scenarios; asserts balance consistency and money conservation across wallets

## Testing
- `DepositIdempotencyIntegrationTest`, `TransferIdempotencyIntegrationTest`, `WithdrawIdempotencyIntegrationTest`
- `TransactionConcurrencyTest`
- Testcontainers used (real PostgreSQL); no H2
- Covers: duplicate key replay, concurrent write contention, insufficient balance under concurrency, money conservation across wallets