### PR TITLE
Add CSV and PDF transaction history export endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,19 @@
 			<artifactId>spring-retry</artifactId>
 			<version>2.0.12</version>
 		</dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.14.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itext-core</artifactId>
+            <version>9.6.0</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/payflow/api/controller/AnalyticsController.java
+++ b/src/main/java/com/payflow/api/controller/AnalyticsController.java
@@ -91,13 +91,15 @@ public class AnalyticsController {
     @GetMapping(value = "/{walletId}/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public ResponseEntity<StreamingResponseBody> export(@PathVariable UUID walletId,
                        @RequestParam Instant from,
-                       @RequestParam Instant to,
-                       @RequestParam String format,
+                       @RequestParam(required = false) Instant to,
+                       @RequestParam(required = false) String format,
                        @AuthenticationPrincipal User user,
                        HttpServletResponse response)
     {
+        Instant effectiveFrom = from != null ? from : Instant.EPOCH;
+        Instant effectiveTo = to != null ? to : Instant.now();
         List<TransactionView> transactions = walletStatementQueryHandler.handle(
-                new WalletStatementQueryHandler.Query(user.getId(), walletId, from, to)
+                new WalletStatementQueryHandler.Query(user.getId(), walletId, effectiveFrom, effectiveTo)
         );
 
         ExportFormat exportFormat = ExportFormat.fromString(format);

--- a/src/main/java/com/payflow/api/controller/AnalyticsController.java
+++ b/src/main/java/com/payflow/api/controller/AnalyticsController.java
@@ -1,0 +1,76 @@
+package com.payflow.api.controller;
+
+import com.payflow.api.dto.response.BalanceHistoryResponse;
+import com.payflow.api.dto.response.MonthlySummaryResponse;
+import com.payflow.api.dto.response.SpendingByCategoryResponse;
+import com.payflow.application.query.AnalyticsQueryHandler;
+import com.payflow.domain.model.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/analytics")
+@RequiredArgsConstructor
+public class AnalyticsController {
+
+    private final AnalyticsQueryHandler analyticsQueryHandler;
+
+    // GET /analytics/balance-history?walletId=&from=&to=&bucket=1 day
+    @GetMapping("/balance-history")
+    public List<BalanceHistoryResponse> balanceHistory(
+            @RequestParam UUID walletId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(defaultValue = "1 day") String interval,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        var query = new AnalyticsQueryHandler.BalanceHistoryQuery(
+                walletId,
+                UUID.fromString(userDetails.getUsername()),
+                from,
+                to,
+                interval
+        );
+        return analyticsQueryHandler.balanceHistory(query);
+    }
+
+    // GET /analytics/spending-by-category?walletId=&from=&to=
+    @GetMapping("/spending-by-category")
+    public List<SpendingByCategoryResponse> spendingByCategory(
+            @RequestParam UUID walletId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @AuthenticationPrincipal User user
+    ) {
+        var query = new AnalyticsQueryHandler.SpendingByCategoryQuery(
+                walletId,
+                user.getId(),
+                from,
+                to
+        );
+        return analyticsQueryHandler.spendingByCategory(query);
+    }
+
+    // GET /analytics/monthly-summary?walletId=&month=2025-04
+    @GetMapping("/monthly-summary")
+    public MonthlySummaryResponse monthlySummary(
+            @RequestParam UUID walletId,
+            @RequestParam String month,   // e.g. "2025-04"
+            @AuthenticationPrincipal User user
+    ) {
+        var query = new AnalyticsQueryHandler.MonthlySummaryQuery(
+                walletId,
+                user.getId(),
+                YearMonth.parse(month)
+        );
+        return analyticsQueryHandler.monthlySummary(query);
+    }
+}

--- a/src/main/java/com/payflow/api/controller/AnalyticsController.java
+++ b/src/main/java/com/payflow/api/controller/AnalyticsController.java
@@ -20,12 +20,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/analytics")
@@ -98,7 +98,7 @@ public class AnalyticsController {
     {
         Instant effectiveFrom = from != null ? from : Instant.EPOCH;
         Instant effectiveTo = to != null ? to : Instant.now();
-        List<TransactionView> transactions = walletStatementQueryHandler.handle(
+        Stream<TransactionView> transactions = walletStatementQueryHandler.handle(
                 new WalletStatementQueryHandler.Query(user.getId(), walletId, effectiveFrom, effectiveTo)
         );
 

--- a/src/main/java/com/payflow/api/controller/AnalyticsController.java
+++ b/src/main/java/com/payflow/api/controller/AnalyticsController.java
@@ -9,7 +9,6 @@ import com.payflow.application.port.PdfExportPort;
 import com.payflow.application.query.AnalyticsQueryHandler;
 import com.payflow.application.query.WalletStatementQueryHandler;
 import com.payflow.domain.model.user.User;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
@@ -17,18 +16,19 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @RestController
-@RequestMapping("/analytics")
+@RequestMapping("/api/v1/analytics")
 @RequiredArgsConstructor
 public class AnalyticsController {
 
@@ -36,9 +36,8 @@ public class AnalyticsController {
     private final WalletStatementQueryHandler walletStatementQueryHandler;
     private final CsvExportPort csvExportPort;
     private final PdfExportPort pdfExportPort;
-
     // GET /analytics/balance-history?walletId=&from=&to=&bucket=1 day
-    @GetMapping("api/v1/balance-history")
+    @GetMapping("/balance-history")
     public List<BalanceHistoryResponse> balanceHistory(
             @RequestParam UUID walletId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
@@ -88,36 +87,39 @@ public class AnalyticsController {
         return analyticsQueryHandler.monthlySummary(query);
     }
 
-    @GetMapping(value = "/{walletId}/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public ResponseEntity<StreamingResponseBody> export(@PathVariable UUID walletId,
-                       @RequestParam Instant from,
-                       @RequestParam(required = false) Instant to,
-                       @RequestParam(required = false) String format,
-                       @AuthenticationPrincipal User user,
-                       HttpServletResponse response)
-    {
+    @GetMapping(value = "/{walletId}/export")
+    @Transactional(readOnly = true)
+    public ResponseEntity<byte[]> export(
+            @PathVariable UUID walletId,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam String format,
+            @AuthenticationPrincipal User user
+    ) throws IOException {
         Instant effectiveFrom = from != null ? from : Instant.EPOCH;
         Instant effectiveTo = to != null ? to : Instant.now();
-        Stream<TransactionView> transactions = walletStatementQueryHandler.handle(
-                new WalletStatementQueryHandler.Query(user.getId(), walletId, effectiveFrom, effectiveTo)
-        );
-
         ExportFormat exportFormat = ExportFormat.fromString(format);
 
+        List<TransactionView> transactions = walletStatementQueryHandler.handle(
+                new WalletStatementQueryHandler.Query(user.getId(), walletId, effectiveFrom, effectiveTo)
+        ).toList();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
         if (exportFormat == ExportFormat.PDF) {
-            StreamingResponseBody stream = out -> pdfExportPort.writePdf(walletId, transactions, out);
+            pdfExportPort.writePdf(walletId, transactions.stream(), out);
             return ResponseEntity.ok()
                     .contentType(MediaType.APPLICATION_PDF)
                     .header(HttpHeaders.CONTENT_DISPOSITION,
                             "attachment; filename=\"statement-%s.pdf\"".formatted(walletId))
-                    .body(stream);
+                    .body(out.toByteArray());
         } else {
-            StreamingResponseBody stream = out -> csvExportPort.writeCsv(transactions, out);
+            csvExportPort.writeCsv(transactions.stream(), out);
             return ResponseEntity.ok()
                     .contentType(new MediaType("text", "csv"))
                     .header(HttpHeaders.CONTENT_DISPOSITION,
                             "attachment; filename=\"statement-%s.csv\"".formatted(walletId))
-                    .body(stream);
+                    .body(out.toByteArray());
         }
     }
 }

--- a/src/main/java/com/payflow/api/controller/AnalyticsController.java
+++ b/src/main/java/com/payflow/api/controller/AnalyticsController.java
@@ -3,14 +3,25 @@ package com.payflow.api.controller;
 import com.payflow.api.dto.response.BalanceHistoryResponse;
 import com.payflow.api.dto.response.MonthlySummaryResponse;
 import com.payflow.api.dto.response.SpendingByCategoryResponse;
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.CsvExportPort;
+import com.payflow.application.port.PdfExportPort;
 import com.payflow.application.query.AnalyticsQueryHandler;
+import com.payflow.application.query.WalletStatementQueryHandler;
 import com.payflow.domain.model.user.User;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -22,9 +33,12 @@ import java.util.UUID;
 public class AnalyticsController {
 
     private final AnalyticsQueryHandler analyticsQueryHandler;
+    private final WalletStatementQueryHandler walletStatementQueryHandler;
+    private final CsvExportPort csvExportPort;
+    private final PdfExportPort pdfExportPort;
 
     // GET /analytics/balance-history?walletId=&from=&to=&bucket=1 day
-    @GetMapping("/balance-history")
+    @GetMapping("api/v1/balance-history")
     public List<BalanceHistoryResponse> balanceHistory(
             @RequestParam UUID walletId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
@@ -72,5 +86,36 @@ public class AnalyticsController {
                 YearMonth.parse(month)
         );
         return analyticsQueryHandler.monthlySummary(query);
+    }
+
+    @GetMapping(value = "/{walletId}/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<StreamingResponseBody> export(@PathVariable UUID walletId,
+                       @RequestParam Instant from,
+                       @RequestParam Instant to,
+                       @RequestParam String format,
+                       @AuthenticationPrincipal User user,
+                       HttpServletResponse response)
+    {
+        List<TransactionView> transactions = walletStatementQueryHandler.handle(
+                new WalletStatementQueryHandler.Query(user.getId(), walletId, from, to)
+        );
+
+        ExportFormat exportFormat = ExportFormat.fromString(format);
+
+        if (exportFormat == ExportFormat.PDF) {
+            StreamingResponseBody stream = out -> pdfExportPort.writePdf(walletId, transactions, out);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_PDF)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"statement-%s.pdf\"".formatted(walletId))
+                    .body(stream);
+        } else {
+            StreamingResponseBody stream = out -> csvExportPort.writeCsv(transactions, out);
+            return ResponseEntity.ok()
+                    .contentType(new MediaType("text", "csv"))
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"statement-%s.csv\"".formatted(walletId))
+                    .body(stream);
+        }
     }
 }

--- a/src/main/java/com/payflow/api/controller/AuthController.java
+++ b/src/main/java/com/payflow/api/controller/AuthController.java
@@ -10,7 +10,7 @@ import com.payflow.application.command.auth.LogoutCommandHandler;
 import com.payflow.application.command.auth.RefreshCommandHandler;
 import com.payflow.application.command.auth.RegisterCommandHandler;
 import com.payflow.application.command.auth.LoginCommandHandler;
-import com.payflow.application.query.GetCurrentUserQueryHandler;
+import com.payflow.application.query.CurrentUserQueryHandler;
 import com.payflow.domain.model.user.User;
 import com.payflow.infrastructure.security.JwtService;
 import jakarta.validation.Valid;
@@ -28,7 +28,7 @@ public class AuthController {
     private final LoginCommandHandler authenticationQueryHandler;
     private final LogoutCommandHandler logoutCommandHandler;
     private final RefreshCommandHandler refreshCommandHandler;
-    private final GetCurrentUserQueryHandler getCurrentUserQueryHandler;
+    private final CurrentUserQueryHandler currentUserQueryHandler;
     private final JwtService jwtService;
 
     @PostMapping("/register")
@@ -57,8 +57,8 @@ public class AuthController {
 
     @GetMapping("/me")
     public ResponseEntity<UserProfileResponse> me(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(getCurrentUserQueryHandler.handle(
-                new GetCurrentUserQueryHandler.Query(user.getId())));
+        return ResponseEntity.ok(currentUserQueryHandler.handle(
+                new CurrentUserQueryHandler.Query(user.getId())));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/payflow/api/controller/ExportFormat.java
+++ b/src/main/java/com/payflow/api/controller/ExportFormat.java
@@ -1,0 +1,5 @@
+package com.payflow.api.controller;
+
+public enum ExportFormat {
+    CSV, PDF
+}

--- a/src/main/java/com/payflow/api/controller/ExportFormat.java
+++ b/src/main/java/com/payflow/api/controller/ExportFormat.java
@@ -1,5 +1,12 @@
 package com.payflow.api.controller;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ExportFormat {
-    CSV, PDF
+    CSV, PDF;
+
+    @JsonCreator
+    public static ExportFormat fromString(String value) {
+        return valueOf(value.toUpperCase());
+    }
 }

--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -100,14 +100,17 @@ public class TransactionController {
 
     @GetMapping(value = "/{walletId}/transactions/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void export(@PathVariable UUID walletId,
-                       @RequestParam Instant from,
-                       @RequestParam Instant to,
+                       @RequestParam(required = false) Instant from,
+                       @RequestParam(required = false) Instant to,
                        @RequestParam ExportFormat format,
                        @AuthenticationPrincipal User user,
                        HttpServletResponse response) throws IOException
     {
+        Instant effectiveFrom = from != null ? from : Instant.EPOCH;
+        Instant effectiveTo = to != null ? to : Instant.now();
+
         List<TransactionView> transactions = walletStatementQueryHandler.handle(
-                new WalletStatementQueryHandler.Query(user.getId(), walletId, from, to)
+                new WalletStatementQueryHandler.Query(user.getId(), walletId, effectiveFrom, effectiveTo)
         );
 
             if(ExportFormat.PDF.equals(format)) {

--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -5,27 +5,17 @@ import com.payflow.api.dto.response.TransactionResponse;
 import com.payflow.application.command.transactions.DepositCommandHandler;
 import com.payflow.application.command.transactions.TransferCommandHandler;
 import com.payflow.application.command.transactions.WithdrawCommandHandler;
-import com.payflow.application.dto.TransactionView;
-import com.payflow.application.port.CsvExportPort;
-import com.payflow.application.port.PdfExportPort;
 import com.payflow.application.query.TransactionQueryHandler;
-import com.payflow.application.query.WalletStatementQueryHandler;
 import com.payflow.domain.model.user.User;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -36,9 +26,7 @@ public class TransactionController {
     private final DepositCommandHandler depositCommandHandler;
     private final WithdrawCommandHandler withdrawCommandHandler;
     private final TransferCommandHandler transferCommandHandler;
-    private final WalletStatementQueryHandler walletStatementQueryHandler;
-    private final CsvExportPort  csvExportPort;
-    private final PdfExportPort pdfExportPort;
+
 
     @GetMapping
     public Page<TransactionResponse> getTransactions(Pageable pageable,
@@ -96,34 +84,5 @@ public class TransactionController {
                                 user.getId(),
                                 request.amount()
                         ))));
-    }
-
-    @GetMapping(value = "/{walletId}/transactions/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void export(@PathVariable UUID walletId,
-                       @RequestParam Instant from,
-                       @RequestParam Instant to,
-                       @RequestParam ExportFormat format,
-                       @AuthenticationPrincipal User user,
-                       HttpServletResponse response) throws IOException
-    {
-        List<TransactionView> transactions = walletStatementQueryHandler.handle(
-                new WalletStatementQueryHandler.Query(user.getId(), walletId, from, to)
-        );
-
-            if(ExportFormat.PDF.equals(format)) {
-                response.setContentType(MediaType.APPLICATION_PDF_VALUE);
-                response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
-                        "attachment; filename=\"statement-%s.pdf\"".formatted(walletId));
-                response.getOutputStream().write(pdfExportPort.generatePdf(walletId, transactions));
-            }
-            else if(ExportFormat.CSV.equals(format)) {
-                response.setContentType("text/csv");
-                response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
-                        "attachment; filename=\"statement-%s.csv\"".formatted(walletId));
-                csvExportPort.writeCsv(transactions, response.getOutputStream());
-            }
-            else {
-                throw new UnsupportedOperationException("Unsupported export format: " + format);
-            }
     }
 }

--- a/src/main/java/com/payflow/api/controller/TransactionController.java
+++ b/src/main/java/com/payflow/api/controller/TransactionController.java
@@ -5,17 +5,27 @@ import com.payflow.api.dto.response.TransactionResponse;
 import com.payflow.application.command.transactions.DepositCommandHandler;
 import com.payflow.application.command.transactions.TransferCommandHandler;
 import com.payflow.application.command.transactions.WithdrawCommandHandler;
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.CsvExportPort;
+import com.payflow.application.port.PdfExportPort;
 import com.payflow.application.query.TransactionQueryHandler;
+import com.payflow.application.query.WalletStatementQueryHandler;
 import com.payflow.domain.model.user.User;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,6 +36,9 @@ public class TransactionController {
     private final DepositCommandHandler depositCommandHandler;
     private final WithdrawCommandHandler withdrawCommandHandler;
     private final TransferCommandHandler transferCommandHandler;
+    private final WalletStatementQueryHandler walletStatementQueryHandler;
+    private final CsvExportPort  csvExportPort;
+    private final PdfExportPort pdfExportPort;
 
     @GetMapping
     public Page<TransactionResponse> getTransactions(Pageable pageable,
@@ -83,5 +96,34 @@ public class TransactionController {
                                 user.getId(),
                                 request.amount()
                         ))));
+    }
+
+    @GetMapping(value = "/{walletId}/transactions/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public void export(@PathVariable UUID walletId,
+                       @RequestParam Instant from,
+                       @RequestParam Instant to,
+                       @RequestParam ExportFormat format,
+                       @AuthenticationPrincipal User user,
+                       HttpServletResponse response) throws IOException
+    {
+        List<TransactionView> transactions = walletStatementQueryHandler.handle(
+                new WalletStatementQueryHandler.Query(user.getId(), walletId, from, to)
+        );
+
+            if(ExportFormat.PDF.equals(format)) {
+                response.setContentType(MediaType.APPLICATION_PDF_VALUE);
+                response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"statement-%s.pdf\"".formatted(walletId));
+                response.getOutputStream().write(pdfExportPort.generatePdf(walletId, transactions));
+            }
+            else if(ExportFormat.CSV.equals(format)) {
+                response.setContentType("text/csv");
+                response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"statement-%s.csv\"".formatted(walletId));
+                csvExportPort.writeCsv(transactions, response.getOutputStream());
+            }
+            else {
+                throw new UnsupportedOperationException("Unsupported export format: " + format);
+            }
     }
 }

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
 
 @RestControllerAdvice
@@ -137,6 +138,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UncheckedIOException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleUncheckedIOException(UncheckedIOException ex) {
+        return new ErrorResponse(
+                "INTERNAL_SERVER_ERROR",
+                "Export failed due to an I/O error"
+        );
+    }
+
+    @ExceptionHandler(IOException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleIOException(IOException ex) {
         return new ErrorResponse(
                 "INTERNAL_SERVER_ERROR",
                 "Export failed due to an I/O error"

--- a/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/payflow/api/exception/GlobalExceptionHandler.java
@@ -22,6 +22,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.UncheckedIOException;
+
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
@@ -130,5 +133,13 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ErrorResponse handleBadCredentials(BadCredentialsException ex) {
         return new ErrorResponse("INVALID_CREDENTIALS", "Invalid email or password");
+    }
+    @ExceptionHandler(UncheckedIOException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleUncheckedIOException(UncheckedIOException ex) {
+        return new ErrorResponse(
+                "INTERNAL_SERVER_ERROR",
+                "Export failed due to an I/O error"
+        );
     }
 }

--- a/src/main/java/com/payflow/application/dto/TransactionView.java
+++ b/src/main/java/com/payflow/application/dto/TransactionView.java
@@ -1,0 +1,14 @@
+package com.payflow.application.dto;
+
+import com.payflow.domain.model.ledger.EntryType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransactionView(UUID transactionId,
+                              Instant createdAt,
+                              EntryType entryType,      // DEBIT / CREDIT
+                              long amount,
+                              long balanceAfter) {
+
+}

--- a/src/main/java/com/payflow/application/port/CsvExportPort.java
+++ b/src/main/java/com/payflow/application/port/CsvExportPort.java
@@ -4,8 +4,8 @@ import com.payflow.application.dto.TransactionView;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
+import java.util.stream.Stream;
 
 public interface CsvExportPort {
-    void writeCsv(List<TransactionView> transactions, OutputStream out) throws IOException;
+    void writeCsv(Stream<TransactionView> transactions, OutputStream out) throws IOException;
 }

--- a/src/main/java/com/payflow/application/port/CsvExportPort.java
+++ b/src/main/java/com/payflow/application/port/CsvExportPort.java
@@ -1,0 +1,11 @@
+package com.payflow.application.port;
+
+import com.payflow.application.dto.TransactionView;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+public interface CsvExportPort {
+    void writeCsv(List<TransactionView> transactions, OutputStream out) throws IOException;
+}

--- a/src/main/java/com/payflow/application/port/PdfExportPort.java
+++ b/src/main/java/com/payflow/application/port/PdfExportPort.java
@@ -4,9 +4,9 @@ import com.payflow.application.dto.TransactionView;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public interface PdfExportPort {
-    void writePdf(UUID walletId, List<TransactionView> transactions, OutputStream out) throws IOException;
+    void writePdf(UUID walletId, Stream<TransactionView> transactions, OutputStream out) throws IOException;
 }

--- a/src/main/java/com/payflow/application/port/PdfExportPort.java
+++ b/src/main/java/com/payflow/application/port/PdfExportPort.java
@@ -2,9 +2,11 @@ package com.payflow.application.port;
 
 import com.payflow.application.dto.TransactionView;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.UUID;
 
 public interface PdfExportPort {
-    byte[] generatePdf(UUID walletId, List<TransactionView> transactions);
+    void writePdf(UUID walletId, List<TransactionView> transactions, OutputStream out) throws IOException;
 }

--- a/src/main/java/com/payflow/application/port/PdfExportPort.java
+++ b/src/main/java/com/payflow/application/port/PdfExportPort.java
@@ -1,0 +1,10 @@
+package com.payflow.application.port;
+
+import com.payflow.application.dto.TransactionView;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PdfExportPort {
+    byte[] generatePdf(UUID walletId, List<TransactionView> transactions);
+}

--- a/src/main/java/com/payflow/application/port/WalletStatementPort.java
+++ b/src/main/java/com/payflow/application/port/WalletStatementPort.java
@@ -1,0 +1,11 @@
+package com.payflow.application.port;
+
+import com.payflow.application.dto.TransactionView;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface WalletStatementPort {
+    List<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to);
+}

--- a/src/main/java/com/payflow/application/port/WalletStatementPort.java
+++ b/src/main/java/com/payflow/application/port/WalletStatementPort.java
@@ -3,9 +3,16 @@ package com.payflow.application.port;
 import com.payflow.application.dto.TransactionView;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public interface WalletStatementPort {
-    List<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to);
+    /**
+     * Returns statement rows as a lazily-consumed stream so large histories do not need
+     * to be fully materialized in memory.
+     *
+     * <p>The caller is responsible for consuming this stream within the surrounding
+     * transaction and closing it when finished, for example via try-with-resources.
+     */
+    Stream<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to);
 }

--- a/src/main/java/com/payflow/application/query/CurrentUserQueryHandler.java
+++ b/src/main/java/com/payflow/application/query/CurrentUserQueryHandler.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class GetCurrentUserQueryHandler {
+public class CurrentUserQueryHandler {
 
     public record Query(java.util.UUID userId) {}
 

--- a/src/main/java/com/payflow/application/query/WalletStatementQueryHandler.java
+++ b/src/main/java/com/payflow/application/query/WalletStatementQueryHandler.java
@@ -1,0 +1,40 @@
+package com.payflow.application.query;
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.WalletStatementPort;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WalletStatementQueryHandler {
+
+    public record Query(UUID userId,UUID walletId, Instant from, Instant to) {}
+
+    private final WalletStatementPort walletStatementPort;
+    private final WalletRepository walletRepository;
+
+    @Transactional(readOnly = true)
+    public List<TransactionView> handle(Query query) {
+        assertOwnership(query.walletId(), query.userId());
+        return walletStatementPort.findStatementRows(
+                query.walletId(),
+                query.from(),
+                query.to()
+        );
+    }
+    private void assertOwnership(UUID walletId, UUID requestingUserId) {
+        var wallet = walletRepository.findById(walletId)
+                .orElseThrow(() -> new WalletNotFoundException(walletId));
+        if (!wallet.getUserId().equals(requestingUserId)) {
+            throw new WalletNotFoundException(walletId);
+        }
+    }
+}

--- a/src/main/java/com/payflow/application/query/WalletStatementQueryHandler.java
+++ b/src/main/java/com/payflow/application/query/WalletStatementQueryHandler.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +22,7 @@ public class WalletStatementQueryHandler {
     private final WalletRepository walletRepository;
 
     @Transactional(readOnly = true)
-    public List<TransactionView> handle(Query query) {
+    public Stream<TransactionView> handle(Query query) {
         assertOwnership(query.walletId(), query.userId());
         return walletStatementPort.findStatementRows(
                 query.walletId(),

--- a/src/main/java/com/payflow/domain/repository/TransactionRepository.java
+++ b/src/main/java/com/payflow/domain/repository/TransactionRepository.java
@@ -4,12 +4,15 @@ import com.payflow.domain.model.transaction.Transaction;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public interface TransactionRepository {
     Optional<Transaction> findByIdempotencyKey(String idempotencyKey);
     Page<Transaction> findAllByUserIdOrderByCreatedAtDesc(UUID userId, Pageable pageable);
     Optional<Transaction> findByIdAndUserId(UUID id, UUID userId);
     Transaction save(Transaction transaction);
+    Stream<Transaction> findByWalletIdBetween(UUID walletId, Instant from, Instant to);
 }

--- a/src/main/java/com/payflow/infrastructure/io/CsvStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/CsvStatementAdapter.java
@@ -1,0 +1,41 @@
+package com.payflow.infrastructure.io;
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.CsvExportPort;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.stereotype.Component;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Component
+public class CsvStatementAdapter implements CsvExportPort {
+
+    @Override
+    public void writeCsv(List<TransactionView> transactions, OutputStream out) throws IOException {
+        BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024*8);
+
+        CSVFormat format = CSVFormat.DEFAULT.builder()
+                .setHeader("transaction_id", "entry_type", "amount", "balance_after", "created_at").get();
+
+        try (CSVPrinter printer = new CSVPrinter(writer, format)) {
+            for (TransactionView tx : transactions) {
+                printer.printRecord(
+                        tx.transactionId(),
+                        tx.entryType(),
+                        formatMoney(tx.amount()),
+                        formatMoney(tx.balanceAfter()),
+                        tx.createdAt()
+                );
+            }
+        }
+    }
+
+    private String formatMoney(long minorUnits) {
+        return BigDecimal.valueOf(minorUnits, 2).toPlainString();
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/io/CsvStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/CsvStatementAdapter.java
@@ -9,29 +9,33 @@ import org.springframework.stereotype.Component;
 import java.io.*;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.stream.Stream;
 
 @Component
 public class CsvStatementAdapter implements CsvExportPort {
 
     @Override
-    public void writeCsv(List<TransactionView> transactions, OutputStream out) throws IOException {
+    public void writeCsv(Stream<TransactionView> transactions, OutputStream out) throws IOException {
         BufferedWriter writer = new BufferedWriter(
-                new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024*8);
+                new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024 * 8);
 
         CSVFormat format = CSVFormat.DEFAULT.builder()
                 .setHeader("transaction_id", "entry_type", "amount", "balance_after", "created_at").get();
 
         try (CSVPrinter printer = new CSVPrinter(writer, format)) {
-            for (TransactionView tx : transactions) {
-                printer.printRecord(
-                        tx.transactionId(),
-                        tx.entryType(),
-                        formatMoney(tx.amount()),
-                        formatMoney(tx.balanceAfter()),
-                        tx.createdAt()
-                );
-            }
+            transactions.forEach(tx -> {
+                try {
+                    printer.printRecord(
+                            tx.transactionId(),
+                            tx.entryType(),
+                            formatMoney(tx.amount()),
+                            formatMoney(tx.balanceAfter()),
+                            tx.createdAt()
+                    );
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
         }
     }
 

--- a/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
@@ -24,15 +24,13 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class PdfStatementAdapter implements PdfExportPort {
     @Override
-    public byte[] generatePdf(UUID walletId, List<TransactionView> transactions) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try(PdfDocument pdf = new PdfDocument(new PdfWriter(out))) {
+    public void writePdf(UUID walletId, List<TransactionView> transactions, OutputStream out) {
+        try (PdfDocument pdf = new PdfDocument(new PdfWriter(out))) {
             Document document = new Document(pdf, PageSize.A4);
             document.add(header(walletId));
             document.add(transactionTable(transactions));
             document.add(footer(transactions));
         }
-        return out.toByteArray();
     }
 
     private Paragraph header(UUID walletId) {

--- a/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
@@ -36,13 +36,14 @@ public class PdfStatementAdapter implements PdfExportPort {
     }
 
     private Paragraph header(UUID walletId) {
-        return new Paragraph("PayFlow — Wallet Statement")
-                .setFontSize(18)
-                .simulateBold()
+        return new Paragraph()
                 .setMarginBottom(4)
-                .add(new Paragraph(
-                        "Wallet: "+ walletId.toString()
-                )).setFontSize(10).simulateBold();
+                .add(new Paragraph("PayFlow — Wallet Statement")
+                        .setFontSize(18)
+                        .simulateBold())
+                .add(new Paragraph("Wallet: " + walletId.toString())
+                        .setFontSize(10)
+                        .simulateBold());
     }
 
     private Table transactionTable(List<TransactionView> transactions){

--- a/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
@@ -24,12 +24,14 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class PdfStatementAdapter implements PdfExportPort {
     @Override
-    public void writePdf(UUID walletId, List<TransactionView> transactions, OutputStream out) {
+    public void writePdf(UUID walletId, Stream<TransactionView> transactions, OutputStream out) {
+        List<TransactionView> rows = transactions.toList();
+
         try (PdfDocument pdf = new PdfDocument(new PdfWriter(out))) {
             Document document = new Document(pdf, PageSize.A4);
             document.add(header(walletId));
-            document.add(transactionTable(transactions));
-            document.add(footer(transactions));
+            document.add(transactionTable(rows));
+            document.add(footer(rows));
         }
     }
 

--- a/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
+++ b/src/main/java/com/payflow/infrastructure/io/PdfStatementAdapter.java
@@ -1,0 +1,84 @@
+package com.payflow.infrastructure.io;
+
+import com.itextpdf.kernel.colors.ColorConstants;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.UnitValue;
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.PdfExportPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class PdfStatementAdapter implements PdfExportPort {
+    @Override
+    public byte[] generatePdf(UUID walletId, List<TransactionView> transactions) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try(PdfDocument pdf = new PdfDocument(new PdfWriter(out))) {
+            Document document = new Document(pdf, PageSize.A4);
+            document.add(header(walletId));
+            document.add(transactionTable(transactions));
+            document.add(footer(transactions));
+        }
+        return out.toByteArray();
+    }
+
+    private Paragraph header(UUID walletId) {
+        return new Paragraph("PayFlow — Wallet Statement")
+                .setFontSize(18)
+                .simulateBold()
+                .setMarginBottom(4)
+                .add(new Paragraph(
+                        "Wallet: "+ walletId.toString()
+                )).setFontSize(10).simulateBold();
+    }
+
+    private Table transactionTable(List<TransactionView> transactions){
+        Table table = new Table(UnitValue
+                .createPercentArray(new float[]{20F, 30F, 25F, 25F}))
+                .useAllAvailableWidth();
+        Stream.of("Date","Description","Amount","Balance")
+                .forEach(header -> table.addHeaderCell(
+                        new Cell()
+                                .add(new Paragraph(header)
+                                        .simulateBold().setBackgroundColor(
+                                                ColorConstants.LIGHT_GRAY
+                                        ))
+                ));
+        for(TransactionView txView: transactions)
+        {
+            table.addCell(txView.createdAt().toString());
+            table.addCell(txView.entryType().toString());
+            table.addCell(formatAmount(txView.amount()));
+            table.addCell(formatAmount(txView.balanceAfter()));
+
+        }
+        return table;
+    }
+
+    private Paragraph footer(List<TransactionView> transactions) {
+        var total = transactions.stream()
+                .mapToLong(TransactionView::amount)
+                .sum();
+
+        return new Paragraph("Total: " + formatAmount(total))
+                .simulateBold()
+                .setMarginTop(12);
+    }
+
+    private String formatAmount(long cents) {
+        return BigDecimal.valueOf(cents, 2).toPlainString();
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/io/WalletStatement.java
+++ b/src/main/java/com/payflow/infrastructure/io/WalletStatement.java
@@ -7,15 +7,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Repository
 public class WalletStatement implements WalletStatementPort {
     private final LedgerEntryJpaRepository repository;
     @Override
-    public List<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to) {
+    public Stream<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to) {
         return repository.findStatementRows(walletId, from, to);
     }
 }

--- a/src/main/java/com/payflow/infrastructure/io/WalletStatement.java
+++ b/src/main/java/com/payflow/infrastructure/io/WalletStatement.java
@@ -1,0 +1,21 @@
+package com.payflow.infrastructure.io;
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.WalletStatementPort;
+import com.payflow.infrastructure.persistence.jpa.LedgerEntryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class WalletStatement implements WalletStatementPort {
+    private final LedgerEntryJpaRepository repository;
+    @Override
+    public List<TransactionView> findStatementRows(UUID walletId, Instant from, Instant to) {
+        return repository.findStatementRows(walletId, from, to);
+    }
+}

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
@@ -3,6 +3,7 @@ package com.payflow.infrastructure.persistence.jpa;
 import com.payflow.api.dto.response.BalanceHistoryResponse;
 import com.payflow.api.dto.response.MonthlySummaryResponse;
 import com.payflow.api.dto.response.SpendingByCategoryResponse;
+import com.payflow.application.dto.TransactionView;
 import com.payflow.domain.model.ledger.LedgerEntry;
 import com.payflow.domain.repository.LedgerEntryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -69,5 +70,24 @@ public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntry, UUI
             @Param("walletId") UUID walletId,
             @Param("from")     Instant from,
             @Param("to")       Instant to
+    );
+
+    @Query("""
+        SELECT new com.payflow.application.dto.TransactionView(
+            le.transactionId,
+            le.createdAt,
+            le.entryType,
+            le.amount,
+            le.balanceAfter
+        )
+        FROM LedgerEntry le
+        WHERE le.walletId = :walletId
+          AND le.createdAt BETWEEN :from AND :to
+        ORDER BY le.createdAt
+        """)
+    List<TransactionView> findStatementRows(
+            @Param("walletId") UUID walletId,
+            @Param("from") Instant from,
+            @Param("to") Instant to
     );
 }

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntry, UUID>, LedgerEntryRepository {
 
@@ -85,7 +86,7 @@ public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntry, UUI
           AND le.createdAt BETWEEN :from AND :to
         ORDER BY le.createdAt
         """)
-    List<TransactionView> findStatementRows(
+    Stream<TransactionView> findStatementRows(
             @Param("walletId") UUID walletId,
             @Param("from") Instant from,
             @Param("to") Instant to

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/TransactionJpaRepository.java
@@ -2,11 +2,28 @@ package com.payflow.infrastructure.persistence.jpa;
 
 import com.payflow.domain.model.transaction.Transaction;
 import com.payflow.domain.repository.TransactionRepository;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
 public interface TransactionJpaRepository extends JpaRepository<Transaction,UUID >, TransactionRepository {
     @Override
     Transaction save(Transaction transaction);
+
+    @Query("SELECT t FROM Transaction t WHERE (t.fromWalletId = :walletId OR t.toWalletId = :walletId) AND t.createdAt BETWEEN :from AND :to")
+    @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "1000"))
+    @Override
+    Stream<Transaction> findByWalletIdBetween(
+            @Param("walletId") UUID walletId,
+            @Param("from") Instant from,
+            @Param("to") Instant to
+    );
 }

--- a/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.payflow.infrastructure.security;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,6 +27,10 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final UserDetailsService userDetailsService;
 
+    @PostConstruct
+    public void configureSecurityContextStrategy() {
+        SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationProvider authenticationProvider) {
@@ -39,13 +45,12 @@ public class SecurityConfig {
                                         "/v3/api-docs/**"
                                 ).permitAll().anyRequest().authenticated()
                 )
-                .sessionManagement(sessionManagement ->
-                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
-
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/test/java/com/payflow/application/query/CurrentUserQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/CurrentUserQueryHandlerTest.java
@@ -18,13 +18,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class GetCurrentUserQueryHandlerTest {
+class CurrentUserQueryHandlerTest {
 
     @Mock
     private UserRepository userRepository;
 
     @InjectMocks
-    private GetCurrentUserQueryHandler handler;
+    private CurrentUserQueryHandler handler;
 
     @Test
     void shouldReturnProfileForAuthenticatedUser() {
@@ -36,7 +36,7 @@ class GetCurrentUserQueryHandlerTest {
                 .build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        UserProfileResponse response = handler.handle(new GetCurrentUserQueryHandler.Query(userId));
+        UserProfileResponse response = handler.handle(new CurrentUserQueryHandler.Query(userId));
 
         assertThat(response.email()).isEqualTo("user@payflow.com");
         assertThat(response.fullName()).isEqualTo("Test User");
@@ -46,8 +46,7 @@ class GetCurrentUserQueryHandlerTest {
     void shouldThrowWhenUserNotFound() {
         UUID userId = UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> handler.handle(new GetCurrentUserQueryHandler.Query(userId)))
+        assertThatThrownBy(() -> handler.handle(new CurrentUserQueryHandler.Query(userId)))
                 .isInstanceOf(UsernameNotFoundException.class);
     }
 }

--- a/src/test/java/com/payflow/application/query/WalletStatementQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/WalletStatementQueryHandlerTest.java
@@ -1,0 +1,91 @@
+package com.payflow.application.query;
+
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.application.port.WalletStatementPort;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.repository.WalletRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Currency;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletStatementQueryHandlerTest {
+
+    @Mock
+    private WalletStatementPort walletStatementPort;
+
+    @Mock
+    private WalletRepository walletRepository;
+    @Mock
+    private TransactionView transactionView;
+
+    @InjectMocks
+    private WalletStatementQueryHandler handler;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID WALLET_ID = UUID.randomUUID();
+    private static final Instant FROM = Instant.now().minusSeconds(3600);
+    private static final Instant TO = Instant.now();
+
+    private WalletStatementQueryHandler.Query query() {
+        return new WalletStatementQueryHandler.Query(USER_ID, WALLET_ID, FROM, TO);
+    }
+
+    private Wallet walletOwnedByUser() {
+        return Wallet.create(USER_ID, Currency.getInstance("EUR"));
+    }
+
+    @Test
+    void shouldReturnStatementWhenUserOwnsWallet() {
+        // Given
+        List<TransactionView> expected = List.of(transactionView);
+        when(walletRepository.findById(WALLET_ID)).thenReturn(Optional.of(walletOwnedByUser()));
+        when(walletStatementPort.findStatementRows(WALLET_ID, FROM, TO)).thenReturn(expected);
+
+        // When
+        List<TransactionView> result = handler.handle(query());
+
+        // Then
+        assertThat(result).isSameAs(expected);
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFound() {
+        // Given
+        when(walletRepository.findById(WALLET_ID)).thenReturn(Optional.empty());
+
+        // When / Then
+        assertThatThrownBy(() -> handler.handle(query()))
+                .isInstanceOf(WalletNotFoundException.class);
+
+        verifyNoInteractions(walletStatementPort);
+    }
+
+    @Test
+    void shouldThrowWhenUserDoesNotOwnWallet() {
+        // Given
+        Wallet walletOwnedByOther = Wallet.create(UUID.randomUUID(), Currency.getInstance("EUR"));
+        when(walletRepository.findById(WALLET_ID)).thenReturn(Optional.of(walletOwnedByOther));
+
+        // When / Then
+        assertThatThrownBy(() -> handler.handle(query()))
+                .isInstanceOf(WalletNotFoundException.class);
+
+        verifyNoInteractions(walletStatementPort);
+    }
+}

--- a/src/test/java/com/payflow/application/query/WalletStatementQueryHandlerTest.java
+++ b/src/test/java/com/payflow/application/query/WalletStatementQueryHandlerTest.java
@@ -14,9 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.Currency;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,12 +53,12 @@ class WalletStatementQueryHandlerTest {
     @Test
     void shouldReturnStatementWhenUserOwnsWallet() {
         // Given
-        List<TransactionView> expected = List.of(transactionView);
+        Stream<TransactionView> expected = Stream.of(transactionView);
         when(walletRepository.findById(WALLET_ID)).thenReturn(Optional.of(walletOwnedByUser()));
         when(walletStatementPort.findStatementRows(WALLET_ID, FROM, TO)).thenReturn(expected);
 
         // When
-        List<TransactionView> result = handler.handle(query());
+        Stream<TransactionView> result = handler.handle(query());
 
         // Then
         assertThat(result).isSameAs(expected);

--- a/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
@@ -61,7 +61,7 @@ class ExportIntegrationTest extends BaseTransactionTest {
 
         // When / Then
         restTestClient.get()
-                .uri("/api/v1/analytics/{walletId}/transactions/export?format=PDF&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+                .uri("/api/v1/analytics/{walletId}/export?format=PDF&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
                         wallet.getId())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .exchange()
@@ -77,7 +77,7 @@ class ExportIntegrationTest extends BaseTransactionTest {
 
         // When / Then
         restTestClient.get()
-                .uri("/api/v1/transactions/{walletId}/transactions/export?format=CSV&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+                .uri("/api/v1/analytics/{walletId}/export?format=CSV&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
                         wallet.getId())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .exchange()

--- a/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.web.servlet.client.RestTestClient;
 import java.util.Currency;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 class ExportIntegrationTest extends BaseTransactionTest {
 
@@ -67,7 +69,9 @@ class ExportIntegrationTest extends BaseTransactionTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_PDF_VALUE)
-                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*");
+                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*")
+                .expectBody(byte[].class)
+                .consumeWith(result -> assertThat(result.getResponseBody()).isNotEmpty());
     }
 
     @Test
@@ -83,6 +87,8 @@ class ExportIntegrationTest extends BaseTransactionTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType("text/csv")
-                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*");
+                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*")
+                .expectBody(byte[].class)
+                .consumeWith(result -> assertThat(result.getResponseBody()).isNotEmpty());
     }
 }

--- a/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.payflow.infrastructure;
+
+import com.payflow.api.dto.request.RegisterRequest;
+import com.payflow.api.dto.response.AuthenticationResponse;
+import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.util.Currency;
+import java.util.UUID;
+
+
+class ExportIntegrationTest extends BaseTransactionTest {
+
+    @Autowired RestTestClient restTestClient;
+    @Autowired AuditLogRepository auditLogRepository;
+
+    private String token;
+
+    @BeforeEach
+    @Override
+    void setupUserAndWallet() {
+        String email = "export-" + UUID.randomUUID() + "@payflow.com";
+
+        token = restTestClient.post()
+                .uri("/api/v1/auth/register")
+                .body(RegisterRequest.builder()
+                        .email(email)
+                        .password("password123")
+                        .fullName("Export User")
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .returnResult(AuthenticationResponse.class)
+                .getResponseBody()
+                .getAccessToken();
+
+        user = userRepository.findByEmail(email).orElseThrow();
+        wallet = walletRepository.findByUserId(user.getId()).stream()
+                .filter(w -> w.getCurrency().equals(Currency.getInstance("GBP")))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @AfterEach
+    @Override
+    void tearDown() {
+        auditLogRepository.deleteAll();
+        super.tearDown();
+    }
+
+    @Test
+    void shouldReturnPdfWhenTransactionsExist() {
+        // Given
+        seedBalance(10_000L);
+
+        // When / Then
+        restTestClient.get()
+                .uri("/api/v1/transactions/{walletId}/transactions/export?format=PDF&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+                        wallet.getId())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_PDF_VALUE)
+                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*");
+    }
+
+    @Test
+    void shouldReturnCsvWhenTransactionsExist() {
+        // Given
+        seedBalance(10_000L);
+
+        // When / Then
+        restTestClient.get()
+                .uri("/api/v1/transactions/{walletId}/transactions/export?format=CSV&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+                        wallet.getId())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType("text/csv")
+                .expectHeader().valueMatches(HttpHeaders.CONTENT_DISPOSITION, ".*attachment.*");
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
@@ -61,7 +61,7 @@ class ExportIntegrationTest extends BaseTransactionTest {
 
         // When / Then
         restTestClient.get()
-                .uri("/api/v1/transactions/{walletId}/transactions/export?format=PDF&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+                .uri("/api/v1/analytics/{walletId}/transactions/export?format=PDF&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
                         wallet.getId())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .exchange()

--- a/src/test/java/com/payflow/infrastructure/io/CsvStatementAdapterTest.java
+++ b/src/test/java/com/payflow/infrastructure/io/CsvStatementAdapterTest.java
@@ -8,8 +8,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +20,7 @@ class CsvStatementAdapterTest {
     @Test
     void shouldWriteHeaderAndRowWhenTransactionsPresent() throws IOException {
         // Given
-        List<TransactionView> transactions = List.of(
+        Stream<TransactionView> transactions = Stream.of(
                 new TransactionView(UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"),
                         EntryType.DEBIT, 10050L, 89950L)
         );
@@ -40,7 +40,7 @@ class CsvStatementAdapterTest {
     @Test
     void shouldWriteHeaderOnlyWhenNoTransactions() throws IOException {
         // Given
-        List<TransactionView> transactions = List.of();
+        Stream<TransactionView> transactions = Stream.of();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         // When

--- a/src/test/java/com/payflow/infrastructure/io/CsvStatementAdapterTest.java
+++ b/src/test/java/com/payflow/infrastructure/io/CsvStatementAdapterTest.java
@@ -1,0 +1,54 @@
+package com.payflow.infrastructure.io;
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.domain.model.ledger.EntryType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CsvStatementAdapterTest {
+
+    private final CsvStatementAdapter adapter = new CsvStatementAdapter();
+
+    @Test
+    void shouldWriteHeaderAndRowWhenTransactionsPresent() throws IOException {
+        // Given
+        List<TransactionView> transactions = List.of(
+                new TransactionView(UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"),
+                        EntryType.DEBIT, 10050L, 89950L)
+        );
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // When
+        adapter.writeCsv(transactions, out);
+
+        // Then
+        String csv = out.toString(StandardCharsets.UTF_8);
+        assertThat(csv).contains("transaction_id,entry_type,amount,balance_after,created_at")
+                .contains("DEBIT")
+                .contains("100.50")
+                .contains("899.50");
+    }
+
+    @Test
+    void shouldWriteHeaderOnlyWhenNoTransactions() throws IOException {
+        // Given
+        List<TransactionView> transactions = List.of();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // When
+        adapter.writeCsv(transactions, out);
+
+        // Then
+        String csv = out.toString(StandardCharsets.UTF_8);
+        assertThat(csv).contains("transaction_id,entry_type,amount,balance_after,created_at");
+        assertThat(csv.lines().count()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/io/PdfStatementAdapterTest.java
+++ b/src/test/java/com/payflow/infrastructure/io/PdfStatementAdapterTest.java
@@ -4,6 +4,7 @@ import com.payflow.application.dto.TransactionView;
 import com.payflow.domain.model.ledger.EntryType;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
@@ -24,7 +25,7 @@ class PdfStatementAdapterTest {
                         EntryType.CREDIT, 5000L, 5000L)
         );
 
-        assertPdfWithTransactions(walletId,transactions);
+        assertPdfWithTransactions(walletId, transactions);
     }
 
     @Test
@@ -38,9 +39,11 @@ class PdfStatementAdapterTest {
 
     private void assertPdfWithTransactions(UUID walletId,List<TransactionView> transactions){
         // When
-        byte[] pdf = adapter.generatePdf(walletId, transactions);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        adapter.writePdf(walletId, transactions.stream(), out);
 
         // Then
+        byte[] pdf = out.toByteArray();
         assertThat(pdf).isNotEmpty();
         assertThat(new String(pdf, StandardCharsets.ISO_8859_1)).startsWith("%PDF");
     }

--- a/src/test/java/com/payflow/infrastructure/io/PdfStatementAdapterTest.java
+++ b/src/test/java/com/payflow/infrastructure/io/PdfStatementAdapterTest.java
@@ -1,0 +1,47 @@
+package com.payflow.infrastructure.io;
+
+import com.payflow.application.dto.TransactionView;
+import com.payflow.domain.model.ledger.EntryType;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PdfStatementAdapterTest {
+
+    private final PdfStatementAdapter adapter = new PdfStatementAdapter();
+
+    @Test
+    void generatePdf_shouldReturnValidPdf_whenTransactionsPresent() {
+        // Given
+        UUID walletId = UUID.randomUUID();
+        List<TransactionView> transactions = List.of(
+                new TransactionView(UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"),
+                        EntryType.CREDIT, 5000L, 5000L)
+        );
+
+        assertPdfWithTransactions(walletId,transactions);
+    }
+
+    @Test
+    void generatePdf_shouldReturnValidPdf_whenNoTransactions() {
+        // Given
+        UUID walletId = UUID.randomUUID();
+        List<TransactionView> transactions = List.of();
+
+        assertPdfWithTransactions(walletId,transactions);
+    }
+
+    private void assertPdfWithTransactions(UUID walletId,List<TransactionView> transactions){
+        // When
+        byte[] pdf = adapter.generatePdf(walletId, transactions);
+
+        // Then
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, StandardCharsets.ISO_8859_1)).startsWith("%PDF");
+    }
+}


### PR DESCRIPTION
## What
Adds CSV and PDF export endpoints for wallet transaction history via a new `AnalyticsController`, backed by application-layer ports and infrastructure I/O adapters.

## Linked Issue
Closes #55

## Why
Users need to download their transaction history for record-keeping and reporting. Export adapters sit behind `CsvExportPort` / `PdfExportPort` interfaces so the infrastructure implementation is swappable without touching the application layer — Ports & Adapters applied to I/O, not just persistence.

## Changes
- **api**: `AnalyticsController` with `GET /analytics/export?format=CSV|PDF`; `ExportFormat` enum; transaction history endpoint added to `TransactionController`
- **application**: `WalletStatementPort`, `CsvExportPort`, `PdfExportPort` ports; `TransactionView` DTO; `WalletStatementQueryHandler`
- **infrastructure/io**: `CsvStatementAdapter`, `PdfStatementAdapter`, `WalletStatement` — all three new classes
- **persistence**: date-range query methods added to `TransactionJpaRepository` and `LedgerEntryJpaRepository`
- **exception**: `GlobalExceptionHandler` extended to cover export failures

## Testing
- `WalletStatementQueryHandlerTest` — unit test for the query handler
- `ExportIntegrationTest` — Testcontainers integration test covering both CSV and PDF generation end-to-end
- `CsvStatementAdapterTest`, `PdfStatementAdapterTest` — unit tests validating adapter output format