### PR TITLE
Migrate JWT tokens to HttpOnly cookies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-        <sonar.organization>lakiidev</sonar.organization>
-        <sonar.projectKey>lakiidev_payflow</sonar.projectKey>
+        <sonar.organization>payflow-organization</sonar.organization>
+        <sonar.projectKey>Payflow-Organization_payflow-backend</sonar.projectKey>
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.build.directory}/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>

--- a/src/main/java/com/payflow/api/controller/AuthController.java
+++ b/src/main/java/com/payflow/api/controller/AuthController.java
@@ -1,18 +1,19 @@
 package com.payflow.api.controller;
 
 import com.payflow.api.dto.request.LoginRequest;
-import com.payflow.api.dto.request.LogoutRequest;
-import com.payflow.api.dto.request.RefreshRequest;
 import com.payflow.api.dto.request.RegisterRequest;
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.api.dto.response.UserProfileResponse;
 import com.payflow.application.command.auth.LogoutCommandHandler;
 import com.payflow.application.command.auth.RefreshCommandHandler;
 import com.payflow.application.command.auth.RegisterCommandHandler;
 import com.payflow.application.command.auth.LoginCommandHandler;
+import com.payflow.application.port.TokenPort;
 import com.payflow.application.query.CurrentUserQueryHandler;
 import com.payflow.domain.model.user.User;
-import com.payflow.infrastructure.security.JwtService;
+import com.payflow.infrastructure.web.CookieService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,30 +30,38 @@ public class AuthController {
     private final LogoutCommandHandler logoutCommandHandler;
     private final RefreshCommandHandler refreshCommandHandler;
     private final CurrentUserQueryHandler currentUserQueryHandler;
-    private final JwtService jwtService;
+    private final TokenPort tokenPort;
+    private final CookieService cookieService;
 
     @PostMapping("/register")
-    public AuthenticationResponse register(@Valid @RequestBody RegisterRequest request) {
-        return registerCommandHandler.handle(new RegisterCommandHandler.Command(
+    public AuthenticationResponse register(@Valid @RequestBody RegisterRequest request, HttpServletResponse response) {
+        AuthTokens auth = registerCommandHandler.handle(new RegisterCommandHandler.Command(
                 request.getEmail(),
                 request.getPassword(),
                 request.getFullName()
         ));
+        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
+        return new AuthenticationResponse(auth.email());
     }
 
     @PostMapping("/login")
-    public AuthenticationResponse login(@Valid @RequestBody LoginRequest request) {
-        return authenticationQueryHandler.handle(new LoginCommandHandler.Command(
+    public AuthenticationResponse login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+        AuthTokens auth = authenticationQueryHandler.handle(new LoginCommandHandler.Command(
                 request.getEmail(),
                 request.getPassword()
         ));
+        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
+        return new AuthenticationResponse(auth.email());
     }
 
     @PostMapping("/refresh")
-    public AuthenticationResponse refresh(@Valid @RequestBody RefreshRequest request) {
-        return refreshCommandHandler.handle(new RefreshCommandHandler.Command(
-                request.getRefreshToken()
-        ));
+    public  ResponseEntity<Void> refresh(@CookieValue("refreshToken") String refreshToken,
+                                          HttpServletResponse response) {
+        AuthTokens auth = refreshCommandHandler.handle(
+                new RefreshCommandHandler.Command(refreshToken)
+        );
+        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")
@@ -63,26 +72,19 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
-            @RequestHeader("Authorization") String authHeader,
-            @RequestBody LogoutRequest request
+            @CookieValue("accessToken") String accessToken,
+            @CookieValue("refreshToken") String refreshToken,
+            HttpServletResponse response
     ) {
-        String accessToken = jwtService.extractBearerToken(authHeader);
-        if (accessToken == null) {
-            return ResponseEntity.status(401).build();
-        }
+        TokenPort.TokenDetails details = tokenPort.extractTokenDetails(accessToken);
+        if (details == null) return ResponseEntity.status(401).build();
 
-        String jti = jwtService.extractJti(accessToken);
-        java.util.Date expiration = jwtService.extractExpiration(accessToken);
-        if (jti == null || expiration == null) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        long ttlSeconds = (expiration.getTime() - System.currentTimeMillis()) / 1000;
         logoutCommandHandler.handle(new LogoutCommandHandler.Command(
-                jti,
-                Math.max(ttlSeconds, 0),
-                request.refreshToken()
+                details.jti(),
+                details.ttlSeconds(),
+                refreshToken
         ));
+        cookieService.removeTokenCookies(response);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/payflow/api/controller/AuthController.java
+++ b/src/main/java/com/payflow/api/controller/AuthController.java
@@ -1,9 +1,10 @@
 package com.payflow.api.controller;
 
 import com.payflow.api.dto.request.LoginRequest;
+import com.payflow.api.dto.request.LogoutRequest;
+import com.payflow.api.dto.request.RefreshRequest;
 import com.payflow.api.dto.request.RegisterRequest;
 import com.payflow.api.dto.response.AuthTokens;
-import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.api.dto.response.UserProfileResponse;
 import com.payflow.application.command.auth.LogoutCommandHandler;
 import com.payflow.application.command.auth.RefreshCommandHandler;
@@ -12,8 +13,6 @@ import com.payflow.application.command.auth.LoginCommandHandler;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.query.CurrentUserQueryHandler;
 import com.payflow.domain.model.user.User;
-import com.payflow.infrastructure.web.CookieService;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,37 +30,29 @@ public class AuthController {
     private final RefreshCommandHandler refreshCommandHandler;
     private final CurrentUserQueryHandler currentUserQueryHandler;
     private final TokenPort tokenPort;
-    private final CookieService cookieService;
 
     @PostMapping("/register")
-    public AuthenticationResponse register(@Valid @RequestBody RegisterRequest request, HttpServletResponse response) {
-        AuthTokens auth = registerCommandHandler.handle(new RegisterCommandHandler.Command(
+    public AuthTokens register(@Valid @RequestBody RegisterRequest request) {
+        return registerCommandHandler.handle(new RegisterCommandHandler.Command(
                 request.getEmail(),
                 request.getPassword(),
                 request.getFullName()
         ));
-        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
-        return new AuthenticationResponse(auth.email());
     }
 
     @PostMapping("/login")
-    public AuthenticationResponse login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
-        AuthTokens auth = authenticationQueryHandler.handle(new LoginCommandHandler.Command(
+    public AuthTokens login(@Valid @RequestBody LoginRequest request) {
+        return authenticationQueryHandler.handle(new LoginCommandHandler.Command(
                 request.getEmail(),
                 request.getPassword()
         ));
-        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
-        return new AuthenticationResponse(auth.email());
     }
 
     @PostMapping("/refresh")
-    public  ResponseEntity<Void> refresh(@CookieValue("refreshToken") String refreshToken,
-                                          HttpServletResponse response) {
-        AuthTokens auth = refreshCommandHandler.handle(
-                new RefreshCommandHandler.Command(refreshToken)
-        );
-        cookieService.setTokenCookies(response, auth.accessToken(), auth.refreshToken());
-        return ResponseEntity.noContent().build();
+    public AuthTokens refresh(@Valid @RequestBody RefreshRequest request) {
+        return refreshCommandHandler.handle(new RefreshCommandHandler.Command(
+                request.getRefreshToken()
+        ));
     }
 
     @GetMapping("/me")
@@ -72,19 +63,20 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
-            @CookieValue("accessToken") String accessToken,
-            @CookieValue("refreshToken") String refreshToken,
-            HttpServletResponse response
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody LogoutRequest request
     ) {
-        TokenPort.TokenDetails details = tokenPort.extractTokenDetails(accessToken);
-        if (details == null) return ResponseEntity.status(401).build();
+        String rawToken = tokenPort.extractBearerToken(authHeader);
+        if (rawToken == null) return ResponseEntity.status(401).build();
+
+        TokenPort.TokenDetails details = tokenPort.extractTokenDetails(rawToken);
+        if (details == null) return ResponseEntity.badRequest().build();
 
         logoutCommandHandler.handle(new LogoutCommandHandler.Command(
                 details.jti(),
                 details.ttlSeconds(),
-                refreshToken
+                request.refreshToken()
         ));
-        cookieService.removeTokenCookies(response);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/payflow/api/dto/response/AuthTokens.java
+++ b/src/main/java/com/payflow/api/dto/response/AuthTokens.java
@@ -1,0 +1,9 @@
+package com.payflow.api.dto.response;
+
+
+
+public record AuthTokens (
+        String accessToken,
+        String refreshToken,
+        String email
+) { }

--- a/src/main/java/com/payflow/api/dto/response/AuthenticationResponse.java
+++ b/src/main/java/com/payflow/api/dto/response/AuthenticationResponse.java
@@ -1,16 +1,4 @@
 package com.payflow.api.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class AuthenticationResponse {
-    private String accessToken;
-    private String refreshToken;
-    private String email;
+public record AuthenticationResponse(String email) {
 }

--- a/src/main/java/com/payflow/application/command/auth/LoginCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/LoginCommandHandler.java
@@ -1,6 +1,7 @@
 package com.payflow.application.command.auth;
 
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
@@ -28,7 +29,7 @@ public class LoginCommandHandler {
     private final RefreshTokenService refreshTokenService;
 
     @Transactional
-    public AuthenticationResponse handle(Command command)
+    public AuthTokens handle(Command command)
     {
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(
                 command.email(),
@@ -40,11 +41,11 @@ public class LoginCommandHandler {
         String rawRefreshToken= refreshTokenService.issue(user.getId());
 
         log.info("User logged in userId={} email={}", user.getId(), user.getUsername());
-        return AuthenticationResponse.builder()
-                .email(user.getUsername())
-                .accessToken(accessToken)
-                .refreshToken(rawRefreshToken)
-                .build();
+        return new AuthTokens(
+                accessToken,
+                rawRefreshToken,
+                command.email()
+        );
     }
 
 

--- a/src/main/java/com/payflow/application/command/auth/RefreshCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/RefreshCommandHandler.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.port.UserPort;
@@ -18,7 +19,7 @@ public class RefreshCommandHandler {
     private final UserPort userPort;
     private final RefreshTokenService refreshTokenService;
     public record Command(String rawRefreshToken) {}
-    public AuthenticationResponse handle(Command command)
+    public AuthTokens handle(Command command)
     {
         RefreshToken token = refreshTokenService.validate(command.rawRefreshToken());
         refreshTokenService.revoke(command.rawRefreshToken());
@@ -29,11 +30,10 @@ public class RefreshCommandHandler {
         String newRefreshToken = refreshTokenService.issue(token.getUserId());
 
         log.info("Refresh token rotated userId={}", token.getUserId());
-        return AuthenticationResponse
-                .builder()
-                .email(userDetails.getUsername())
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .build();
+        return new AuthTokens(
+                newAccessToken,
+                newRefreshToken,
+                userDetails.getUsername()
+        );
     }
 }

--- a/src/main/java/com/payflow/application/command/auth/RegisterCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/auth/RegisterCommandHandler.java
@@ -2,6 +2,7 @@
 
 package com.payflow.application.command.auth;
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
@@ -35,7 +36,7 @@ public class RegisterCommandHandler {
     private final TokenPort tokenPort;
 
     @Transactional // For future use, convention wise atm
-    public AuthenticationResponse handle(Command command) {
+    public AuthTokens handle(Command command) {
         if (userRepository.existsByEmail(command.email())) {
             throw new EmailAlreadyRegisteredException(command.email());
         }
@@ -52,10 +53,10 @@ public class RegisterCommandHandler {
         String accessToken = tokenPort.generateAccessToken(user);
         String rawRefreshToken = refreshTokenService.issue(user.getId());
         log.info("User logged in userId={} walletID={}", user.getId(), wallet.getId());
-        return AuthenticationResponse.builder()
-                .email(user.getUsername())
-                .accessToken(accessToken)
-                .refreshToken(rawRefreshToken)
-                .build();
+        return new AuthTokens(
+                accessToken,
+                rawRefreshToken,
+                command.email()
+        );
     }
 }

--- a/src/main/java/com/payflow/application/port/TokenPort.java
+++ b/src/main/java/com/payflow/application/port/TokenPort.java
@@ -3,8 +3,11 @@ package com.payflow.application.port;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public interface TokenPort {
+    record TokenDetails(String jti, long ttlSeconds) {}
+
     String generateAccessToken(UserDetails userDetails);
     boolean validateToken(String token, UserDetails userDetails);
     String extractUsername(String token);
     String extractBearerToken(String authorizationHeader);
+    TokenDetails extractTokenDetails(String rawToken);
 }

--- a/src/main/java/com/payflow/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.payflow.infrastructure.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
@@ -32,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain
     ) throws ServletException, IOException {
-        final String jwt = jwtService.extractBearerToken(request.getHeader("Authorization"));
+        final String jwt = extractToken(request);
         final String userEmail;
         if (jwt == null) {
             filterChain.doFilter(request, response);
@@ -56,4 +57,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         filterChain.doFilter(request, response);
     }
+    private String extractToken(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return jwtService.extractBearerToken(request.getHeader("Authorization"));
+    }
 }
+

--- a/src/main/java/com/payflow/infrastructure/security/JwtService.java
+++ b/src/main/java/com/payflow/infrastructure/security/JwtService.java
@@ -48,6 +48,15 @@ public class JwtService extends TokenService implements TokenPort {
         return extractClaim(token, Claims::getId);
     }
 
+    @Override
+    public TokenDetails extractTokenDetails(String rawToken) {
+        String jti = extractJti(rawToken);
+        Date expiration = extractExpiration(rawToken);
+        if (jti == null || expiration == null) return null;
+        long ttlSeconds = Math.max(0, (expiration.getTime() - System.currentTimeMillis()) / 1000);
+        return new TokenDetails(jti, ttlSeconds);
+    }
+
     private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
         if (claims == null) return null;

--- a/src/main/java/com/payflow/infrastructure/web/CookieService.java
+++ b/src/main/java/com/payflow/infrastructure/web/CookieService.java
@@ -1,0 +1,40 @@
+package com.payflow.infrastructure.web;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CookieService {
+
+    @Value("${app.jwt.expiration}")
+    private long accessTokenExpirationMs;
+
+    @Value("${app.jwt.refresh-expiration}")
+    private long refreshTokenExpirationMs;
+
+    public void setTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                buildCookie("accessToken", accessToken, (int) (accessTokenExpirationMs / 1000)));
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                buildCookie("refreshToken", refreshToken, (int) (refreshTokenExpirationMs / 1000)));
+    }
+
+    public void removeTokenCookies(HttpServletResponse response) {
+        response.addHeader(HttpHeaders.SET_COOKIE, buildCookie("accessToken", "", 0));
+        response.addHeader(HttpHeaders.SET_COOKIE, buildCookie("refreshToken", "", 0));
+    }
+
+    private String buildCookie(String name, String value, int maxAge) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(maxAge)
+                .path("/")
+                .sameSite("Strict")
+                .build()
+                .toString();
+    }
+}

--- a/src/test/java/com/payflow/application/command/auth/LoginCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LoginCommandHandlerTest.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
@@ -57,11 +58,11 @@ class LoginCommandHandlerTest {
         when(refreshTokenService.issue(any())).thenReturn("refresh-token");
 
         // When
-        AuthenticationResponse response = handler.handle(command);
+        AuthTokens response = handler.handle(command);
 
         // Then
-        assertThat(response.getAccessToken()).isEqualTo("access-token");
-        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
         verify(authenticationManager).authenticate(any());
     }
 

--- a/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/LogoutIntegrationTest.java
@@ -3,6 +3,7 @@ package com.payflow.application.command.auth;
 import com.payflow.BaseIntegrationTest;
 import com.payflow.api.dto.request.LogoutRequest;
 import com.payflow.api.dto.request.RegisterRequest;
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.domain.model.token.RefreshToken;
 import com.payflow.domain.repository.RefreshTokenRepository;
@@ -28,7 +29,7 @@ class LogoutIntegrationTest extends BaseIntegrationTest {
         // Setup — register and get tokens
         String email = "logout-" + UUID.randomUUID() + "@payflow.com";
 
-        AuthenticationResponse response = restTestClient.post()
+        AuthTokens response = restTestClient.post()
                 .uri("/api/v1/auth/register")
                 .body(RegisterRequest.builder()
                         .email(email)
@@ -37,20 +38,20 @@ class LogoutIntegrationTest extends BaseIntegrationTest {
                         .build())
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(AuthenticationResponse.class)
+                .expectBody(AuthTokens.class)
                 .returnResult()
                 .getResponseBody();
 
         // When
         restTestClient.post()
                 .uri("/api/v1/auth/logout")
-                .body(new LogoutRequest(response.getRefreshToken()))
-                .header("Authorization", "Bearer " + response.getAccessToken())
+                .body(new LogoutRequest(response.refreshToken()))
+                .header("Authorization", "Bearer " + response.accessToken())
                 .exchange()
                 .expectStatus().isNoContent();
 
         // Then — refresh token revoked in DB
-        String hash = sha256Hex(response.getRefreshToken());
+        String hash = sha256Hex(response.refreshToken());
         assertThat(refreshTokenRepository.findByTokenHash(hash))
                 .isPresent()
                 .get()

--- a/src/test/java/com/payflow/application/command/auth/RefreshCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RefreshCommandHandlerTest.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.port.UserPort;
@@ -50,11 +51,11 @@ class RefreshCommandHandlerTest {
         when(refreshTokenService.issue(userId)).thenReturn("new-refresh");
 
         // When
-        AuthenticationResponse response = handler.handle(new RefreshCommandHandler.Command("old-token"));
+        AuthTokens response = handler.handle(new RefreshCommandHandler.Command("old-token"));
 
         // Then
-        assertThat(response.getAccessToken()).isEqualTo("new-access");
-        assertThat(response.getRefreshToken()).isEqualTo("new-refresh");
+        assertThat(response.accessToken()).isEqualTo("new-access");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh");
         verify(refreshTokenService).revoke("old-token");
     }
 

--- a/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RefreshTokenIntegrationTest.java
@@ -3,6 +3,7 @@ package com.payflow.application.command.auth;
 import com.payflow.BaseIntegrationTest;
 import com.payflow.api.dto.request.RefreshRequest;
 import com.payflow.api.dto.request.RegisterRequest;
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.domain.model.token.RefreshToken;
 import com.payflow.domain.repository.RefreshTokenRepository;
@@ -35,7 +36,7 @@ class RefreshTokenIntegrationTest extends BaseIntegrationTest {
     void setUp() {
         userEmail = "refresh-" + UUID.randomUUID() + "@payflow.com";
 
-        AuthenticationResponse response = restTestClient.post()
+        AuthTokens response = restTestClient.post()
                 .uri("/api/v1/auth/register")
                 .body(RegisterRequest.builder()
                         .email(userEmail)
@@ -44,11 +45,11 @@ class RefreshTokenIntegrationTest extends BaseIntegrationTest {
                         .build())
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(AuthenticationResponse.class)
+                .expectBody(AuthTokens.class)
                 .returnResult()
                 .getResponseBody();
 
-        rawRefreshToken = response.getRefreshToken();
+        rawRefreshToken = response.refreshToken();
     }
 
     @Test

--- a/src/test/java/com/payflow/application/command/auth/RegisterCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/auth/RegisterCommandHandlerTest.java
@@ -1,5 +1,6 @@
 package com.payflow.application.command.auth;
 
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.api.dto.response.AuthenticationResponse;
 import com.payflow.application.port.TokenPort;
 import com.payflow.application.service.RefreshTokenService;
@@ -64,12 +65,12 @@ class RegisterCommandHandlerTest {
         when(refreshTokenService.issue(any())).thenReturn("refresh-token");
 
         // When
-        AuthenticationResponse response = handler.handle(command);
+        AuthTokens response = handler.handle(command);
 
         // Then
-        assertThat(response.getAccessToken()).isEqualTo("access-token");
-        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
-        assertThat(response.getEmail()).isEqualTo("test@payflow.com");
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        assertThat(response.email()).isEqualTo("test@payflow.com");
         verify(userRepository).save(any(User.class));
         verify(walletService).save(any(Wallet.class));
         verify(passwordEncoder).encode("password123");

--- a/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
+++ b/src/test/java/com/payflow/infrastructure/ExportIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.payflow.infrastructure;
 
 import com.payflow.api.dto.request.RegisterRequest;
-import com.payflow.api.dto.response.AuthenticationResponse;
+import com.payflow.api.dto.response.AuthTokens;
 import com.payflow.infrastructure.persistence.jpa.AuditLogRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,9 +38,9 @@ class ExportIntegrationTest extends BaseTransactionTest {
                         .build())
                 .exchange()
                 .expectStatus().isOk()
-                .returnResult(AuthenticationResponse.class)
+                .returnResult(AuthTokens.class)
                 .getResponseBody()
-                .getAccessToken();
+                .accessToken();
 
         user = userRepository.findByEmail(email).orElseThrow();
         wallet = walletRepository.findByUserId(user.getId()).stream()

--- a/src/test/java/com/payflow/infrastructure/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/payflow/infrastructure/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,175 @@
+package com.payflow.infrastructure.security;
+
+import com.payflow.domain.model.user.User;
+import com.payflow.domain.model.user.UserStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock JwtService jwtService;
+    @Mock UserDetailsService userDetailsService;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock FilterChain filterChain;
+
+    @InjectMocks JwtAuthenticationFilter filter;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private UserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        userDetails = User.builder()
+                .email("test@payflow.com")
+                .passwordHash("hashed")
+                .fullName("Test User")
+                .status(UserStatus.ACTIVE)
+                .build();
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldPassThroughUnauthenticatedWhenNoToken() throws Exception {
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verifyNoInteractions(userDetailsService);
+    }
+
+    @Test
+    void shouldAuthenticateWithValidBearerToken() throws Exception {
+        request.addHeader("Authorization", "Bearer valid-token");
+        when(jwtService.extractBearerToken("Bearer valid-token")).thenReturn("valid-token");
+        when(jwtService.extractUsername("valid-token")).thenReturn("test@payflow.com");
+        when(userDetailsService.loadUserByUsername("test@payflow.com")).thenReturn(userDetails);
+        when(jwtService.validateToken("valid-token", userDetails)).thenReturn(true);
+        when(jwtService.extractJti("valid-token")).thenReturn("jti-abc");
+        when(redisTemplate.hasKey("denylist:jti-abc")).thenReturn(false);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(userDetails);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void shouldExtractTokenFromCookie() throws Exception {
+        request.setCookies(new Cookie("accessToken", "cookie-token"));
+        when(jwtService.extractUsername("cookie-token")).thenReturn("test@payflow.com");
+        when(userDetailsService.loadUserByUsername("test@payflow.com")).thenReturn(userDetails);
+        when(jwtService.validateToken("cookie-token", userDetails)).thenReturn(true);
+        when(jwtService.extractJti("cookie-token")).thenReturn("jti-cookie");
+        when(redisTemplate.hasKey("denylist:jti-cookie")).thenReturn(false);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        verify(jwtService, never()).extractBearerToken(any());
+    }
+
+    @Test
+    void shouldPreferCookieOverAuthorizationHeader() throws Exception {
+        request.setCookies(new Cookie("accessToken", "cookie-token"));
+        request.addHeader("Authorization", "Bearer header-token");
+        when(jwtService.extractUsername("cookie-token")).thenReturn("test@payflow.com");
+        when(userDetailsService.loadUserByUsername("test@payflow.com")).thenReturn(userDetails);
+        when(jwtService.validateToken("cookie-token", userDetails)).thenReturn(true);
+        when(jwtService.extractJti("cookie-token")).thenReturn("jti-cookie");
+        when(redisTemplate.hasKey("denylist:jti-cookie")).thenReturn(false);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(jwtService, never()).extractBearerToken(any());
+        verify(jwtService, never()).extractUsername("header-token");
+    }
+
+    @Test
+    void shouldReturn401AndNotCallChainWhenTokenInDenylist() throws Exception {
+        request.addHeader("Authorization", "Bearer denied-token");
+        when(jwtService.extractBearerToken("Bearer denied-token")).thenReturn("denied-token");
+        when(jwtService.extractUsername("denied-token")).thenReturn("test@payflow.com");
+        when(userDetailsService.loadUserByUsername("test@payflow.com")).thenReturn(userDetails);
+        when(jwtService.validateToken("denied-token", userDetails)).thenReturn(true);
+        when(jwtService.extractJti("denied-token")).thenReturn("jti-denied");
+        when(redisTemplate.hasKey("denylist:jti-denied")).thenReturn(true);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void shouldPassThroughUnauthenticatedWhenTokenFailsValidation() throws Exception {
+        request.addHeader("Authorization", "Bearer bad-token");
+        when(jwtService.extractBearerToken("Bearer bad-token")).thenReturn("bad-token");
+        when(jwtService.extractUsername("bad-token")).thenReturn("test@payflow.com");
+        when(userDetailsService.loadUserByUsername("test@payflow.com")).thenReturn(userDetails);
+        when(jwtService.validateToken("bad-token", userDetails)).thenReturn(false);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(redisTemplate);
+    }
+
+    @Test
+    void shouldPassThroughUnauthenticatedWhenUsernameIsNull() throws Exception {
+        request.addHeader("Authorization", "Bearer malformed");
+        when(jwtService.extractBearerToken("Bearer malformed")).thenReturn("malformed");
+        when(jwtService.extractUsername("malformed")).thenReturn(null);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(userDetailsService, redisTemplate);
+    }
+
+    @Test
+    void shouldSkipUserLookupWhenAlreadyAuthenticated() throws Exception {
+        request.addHeader("Authorization", "Bearer valid-token");
+        when(jwtService.extractBearerToken("Bearer valid-token")).thenReturn("valid-token");
+        when(jwtService.extractUsername("valid-token")).thenReturn("test@payflow.com");
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+
+        filter.doFilter(request, response, filterChain);
+
+        verifyNoInteractions(userDetailsService, redisTemplate);
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/payflow/infrastructure/web/CookieServiceTest.java
+++ b/src/test/java/com/payflow/infrastructure/web/CookieServiceTest.java
@@ -1,0 +1,77 @@
+package com.payflow.infrastructure.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CookieServiceTest {
+
+    private CookieService cookieService;
+
+    @BeforeEach
+    void setUp() {
+        cookieService = new CookieService();
+        ReflectionTestUtils.setField(cookieService, "accessTokenExpirationMs", 900_000L);
+        ReflectionTestUtils.setField(cookieService, "refreshTokenExpirationMs", 604_800_000L);
+    }
+
+    @Test
+    void shouldSetBothCookiesWithCorrectAttributes() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        cookieService.setTokenCookies(response, "acc-tok", "ref-tok");
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(2);
+
+        String accessCookie = cookies.get(0);
+        assertThat(accessCookie).contains("accessToken=acc-tok")
+                .containsIgnoringCase("HttpOnly")
+                .containsIgnoringCase("Secure")
+                .containsIgnoringCase("SameSite=Strict")
+                .contains("Path=/")
+                .contains("Max-Age=900");
+
+        String refreshCookie = cookies.get(1);
+        assertThat(refreshCookie).contains("refreshToken=ref-tok")
+                .contains("Max-Age=604800");
+    }
+
+    @Test
+    void shouldClearBothCookiesBySettingMaxAgeZero() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        cookieService.removeTokenCookies(response);
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(2);
+
+        String accessCookie = cookies.get(0);
+        assertThat(accessCookie).contains("accessToken=")
+                .contains("Max-Age=0");
+
+        String refreshCookie = cookies.get(1);
+        assertThat(refreshCookie).contains("refreshToken=")
+                .contains("Max-Age=0");
+    }
+
+    @Test
+    void shouldPreserveSecurityAttributesOnRemove() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        cookieService.removeTokenCookies(response);
+
+        for (String cookie : response.getHeaders(HttpHeaders.SET_COOKIE)) {
+            assertThat(cookie).containsIgnoringCase("HttpOnly");
+            assertThat(cookie).containsIgnoringCase("Secure");
+            assertThat(cookie).containsIgnoringCase("SameSite=Strict");
+            assertThat(cookie).contains("Path=/");
+        }
+    }
+}


### PR DESCRIPTION
## What
Replace JSON-body token responses with HttpOnly cookies for all auth endpoints and update the JWT filter to extract the access token from the cookie first.

## Linked Issue
Closes #76

## Why
Returning raw tokens in the response body exposes them to JavaScript, making XSS trivially able to steal them. HttpOnly cookies are inaccessible to JS and are the standard secure transport for session tokens (M4 — Security).

## Changes
- **api**: `AuthController` — `/login`, `/register`, `/refresh`, and `/logout` now set/clear cookies via `CookieService`; `/refresh` and `/logout` read tokens via `@CookieValue` instead of request body; `/logout` reads access token from `accessToken` cookie instead of `Authorization` header
- **security**: `JwtAuthenticationFilter` — checks `accessToken` cookie before falling back to `Authorization` header
- **security**: `TokenPort` — adds `TokenDetails` record and `extractTokenDetails(String rawToken)`; `JwtService` implements it using existing `extractJti` + `extractExpiration`
- **infra**: New `CookieService` — builds HttpOnly, Secure, SameSite=Strict cookies using `ResponseCookie`; reads expiration from `app.jwt.expiration` / `app.jwt.refresh-expiration`
- **dto**: `AuthenticationResponse` slimmed to `email` only; new internal `AuthTokens` record carries tokens between command handlers and controller

## Testing
- `LoginCommandHandlerTest`, `RegisterCommandHandlerTest`, `RefreshCommandHandlerTest` updated for `AuthTokens` return type
- `LogoutIntegrationTest`, `RefreshTokenIntegrationTest` updated for cookie-based flow
- Testcontainers used for all integration tests