### PR TITLE
Add multi-stage Dockerfile and production config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+
+.git/
+.github/
+
+.env
+*.md
+
+docker-compose*.yml
+*.log
+.idea/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /mvnw text eol=lf
 *.cmd text eol=crlf
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
+      - name: Make mvnw executable
+        run: chmod +x mvnw
+
       - name: Build, test and analyze
         run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,80 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
 
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Build, test and analyze
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/payflow-organization/payflow-backend:${{ github.sha }}
+            ghcr.io/payflow-organization/payflow-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to Railway
+    runs-on: ubuntu-latest
+    needs: docker
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@4.57.5 --ignore-scripts
+
+      - name: Deploy
+        run: railway up --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Builder
+FROM eclipse-temurin:25-jdk-alpine AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+COPY .mvn .mvn
+COPY mvnw .
+RUN chmod +x mvnw
+
+RUN ./mvnw dependency:go-offline -B
+COPY src src
+
+RUN ./mvnw clean package -DskipTests -B
+
+#Runtime
+FROM eclipse-temurin:25-jre-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/target/payflow-*.jar app.jar
+RUN addgroup -S payflow && adduser -S payflow -G payflow
+USER payflow
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD wget -qO- http://localhost:8080/actuator/health
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", \
+    "-Dspring.profiles.active=prod", \
+    "-XX:+UseG1GC", \
+    "-XX:InitialRAMPercentage=50.0", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-XX:+UseStringDeduplication", \
+    "-jar", "app.jar"]
+

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "builder": "DOCKERFILE"
+  }
+}

--- a/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/payflow/infrastructure/security/SecurityConfig.java
@@ -43,7 +43,9 @@ public class SecurityConfig {
                                         "/swagger-ui/**",
                                         "/swagger-ui.html",
                                         "/v3/api-docs/**"
-                                ).permitAll().anyRequest().authenticated()
+                                ).permitAll()
+                                .requestMatchers("/actuator/health").permitAll()
+                                .anyRequest().authenticated()
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,23 +1,80 @@
-spring:
-  datasource:
-    write:
-      url: ${DB_WRITE_URL}
-      username: ${DB_USER}
-      password: ${DB_PASSWORD}
-      driver-class-name: org.postgresql.Driver
-    read:
-      url: ${DB_READ_URL}
-      username: ${DB_USER}
-      password: ${DB_PASSWORD}
-      driver-class-name: org.postgresql.Driver
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT:6379}
-      timeout: 2000ms
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+name: CI
 
-logging:
-  level:
-    com.payflow: INFO
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Build, test and analyze
+        run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/payflow-organization/payflow-backend:${{ github.sha }}
+            ghcr.io/payflow-organization/payflow-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to Railway
+    runs-on: ubuntu-latest
+    needs: docker
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy
+        run: railway up --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,22 +1,22 @@
 spring:
   datasource:
     write:
-      url: jdbc:postgresql://postgres-primary:5432/payflow
+      url: ${DB_WRITE_URL}
       username: ${DB_USER}
       password: ${DB_PASSWORD}
       driver-class-name: org.postgresql.Driver
     read:
-      url: jdbc:postgresql://postgres-replica:5432/payflow
+      url: ${DB_READ_URL}
       username: ${DB_USER}
       password: ${DB_PASSWORD}
       driver-class-name: org.postgresql.Driver
   data:
     redis:
-      host: redis
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
       timeout: 2000ms
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,11 +17,11 @@ spring:
   datasource:
     write:
       url: ${DB_WRITE_URL}
-      username: ${DB_USERNAME}
+      username: ${DB_USER}
       password: ${DB_PASSWORD}
     read:
       url: ${DB_READ_URL}
-      username: ${DB_USERNAME}
+      username: ${DB_USER}
       password: ${DB_PASSWORD}
 
   kafka:

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -1,12 +1,10 @@
 package com.payflow;
 
+import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.DynamicPropertyRegistrar;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -22,18 +20,9 @@ public class TestcontainersConfiguration {
     }
 
     @Bean
+    @ServiceConnection
     @RestartScope
-    GenericContainer<?> redisContainer() {
-        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
-                .withExposedPorts(6379)
-                .waitingFor(Wait.forListeningPort());
-    }
-
-    @Bean
-    DynamicPropertyRegistrar redisProperties(GenericContainer<?> redisContainer) {
-        return registry -> {
-            registry.add("spring.data.redis.host", redisContainer::getHost);
-            registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
-        };
+    RedisContainer redisContainer() {
+        return new RedisContainer(DockerImageName.parse("redis:7-alpine"));
     }
 }

--- a/src/test/java/com/payflow/TestcontainersConfiguration.java
+++ b/src/test/java/com/payflow/TestcontainersConfiguration.java
@@ -1,10 +1,12 @@
 package com.payflow;
 
-import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -20,9 +22,18 @@ public class TestcontainersConfiguration {
     }
 
     @Bean
-    @ServiceConnection
     @RestartScope
-    RedisContainer redisContainer() {
-        return new RedisContainer(DockerImageName.parse("redis:7-alpine"));
+    GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                .withExposedPorts(6379)
+                .waitingFor(Wait.forListeningPort());
+    }
+
+    @Bean
+    DynamicPropertyRegistrar redisProperties(GenericContainer<?> redisContainer) {
+        return registry -> {
+            registry.add("spring.data.redis.host", redisContainer::getHost);
+            registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+        };
     }
 }


### PR DESCRIPTION
## What
Add a multi-stage Dockerfile, .dockerignore, and a production Spring profile that reads all infrastructure coordinates from environment variables.

## Linked Issue
Closes #72
Closes #74

## Why
A single-stage build ships Maven and the full JDK into the runtime image (~600 MB). Splitting into build + runtime stages reduces the image to ~200 MB and removes build tooling from the attack surface. Permitting `/actuator/health` without authentication is required so the Docker HEALTHCHECK probe can reach it — without this the container never leaves the unhealthy state.

## Changes
- **Dockerfile** — builder stage uses `eclipse-temurin:25-jdk-alpine` to resolve dependencies offline then package; runtime stage uses `eclipse-temurin:25-jre-alpine`, creates a non-root `payflow` user, sets G1GC + RAM-percentage JVM flags, and exposes a `/actuator/health` HEALTHCHECK
- **infra**: `.dockerignore` — excludes `target/`, `.git/`, `.env`, logs, and IDE files from the build context
- **infra**: `application-docker.yml` renamed to `application-prod.yml`; hardcoded hostnames replaced with `${DB_WRITE_URL}`, `${DB_READ_URL}`, `${REDIS_HOST}`, `${REDIS_PORT}`, `${KAFKA_BOOTSTRAP_SERVERS}`
- **infra**: `application.yml` — datasource username env var unified to `${DB_USER}` (was `${DB_USERNAME}`)
- **security**: `SecurityConfig` — `/actuator/health` permitted without authentication; all other `/actuator/**` endpoints remain protected