### PR TITLE
Add unfreeze wallet endpoint and fix spending category query

### DIFF
--- a/src/main/java/com/payflow/api/controller/WalletController.java
+++ b/src/main/java/com/payflow/api/controller/WalletController.java
@@ -5,6 +5,7 @@ import com.payflow.api.dto.response.BalanceResponse;
 import com.payflow.api.dto.response.WalletResponse;
 import com.payflow.application.command.wallet.CreateWalletCommandHandler;
 import com.payflow.application.command.wallet.FreezeWalletCommandHandler;
+import com.payflow.application.command.wallet.UnfreezeWalletCommandHandler;
 import com.payflow.application.query.wallet.GetWalletBalanceQueryHandler;
 import com.payflow.application.query.wallet.WalletQueryHandler;
 import com.payflow.domain.model.user.User;
@@ -26,6 +27,7 @@ public class WalletController {
     private final WalletQueryHandler walletQueryHandler;
     private final CreateWalletCommandHandler createWalletCommandHandler;
     private final FreezeWalletCommandHandler freezeWalletCommandHandler;
+    private final UnfreezeWalletCommandHandler unfreezeWalletCommandHandler;
     private final GetWalletBalanceQueryHandler getWalletBalanceQueryHandler;
 
     @GetMapping
@@ -58,4 +60,11 @@ public class WalletController {
         freezeWalletCommandHandler.handle(new FreezeWalletCommandHandler.Command(id, user.getId()));
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{id}/unfreeze")
+    public ResponseEntity<Void> unfreeze(@PathVariable UUID id, @AuthenticationPrincipal User user) {
+        unfreezeWalletCommandHandler.handle(new UnfreezeWalletCommandHandler.Command(id, user.getId()));
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/payflow/application/command/wallet/UnfreezeWalletCommandHandler.java
+++ b/src/main/java/com/payflow/application/command/wallet/UnfreezeWalletCommandHandler.java
@@ -1,0 +1,72 @@
+package com.payflow.application.command.wallet;
+
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.repository.WalletRepository;
+
+import java.util.UUID;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UnfreezeWalletCommandHandler {
+
+    public record Command(UUID walletId, UUID userId) {}
+
+    private final WalletRepository walletRepository;
+    private final WalletService walletService;
+    private final MeterRegistry meterRegistry;
+    private static final String CURRENCY_TAG = "currency";
+
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class, PessimisticLockingFailureException.class},
+            maxAttemptsExpression = "${payflow.retry.max-attempts:3}",
+            backoff = @Backoff(
+                    delayExpression = "${payflow.retry.initial-interval-ms:100}",
+                    multiplierExpression = "${payflow.retry.multiplier:2.0}",
+                    maxDelayExpression = "${payflow.retry.max-interval-ms:1000}"
+            )
+    )
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public void handle(Command command) {
+        Timer.Sample timer = Timer.start(meterRegistry);
+        String currency = "unknown";
+        try {
+            Wallet wallet = walletRepository.findByIdAndUserId(command.walletId(), command.userId())
+                    .orElseThrow(() -> {
+                        meterRegistry.counter("payflow.wallet.unfreeze.failure",
+                                CURRENCY_TAG, "unknown",
+                                "reason", "not_found"
+                        ).increment();
+                        return new WalletNotFoundException(command.walletId());
+                    });
+
+            currency = wallet.getCurrency().getCurrencyCode();
+            wallet.unfreeze();
+
+            meterRegistry.counter("payflow.wallet.unfreeze.success",
+                    CURRENCY_TAG, currency
+            ).increment();
+
+            log.info("Wallet unfrozen walletId={} userId={}", command.walletId(), command.userId());
+            walletService.save(wallet);
+        } finally {
+            timer.stop(Timer.builder("payflow.wallet.unfreeze.latency")
+                    .tag(CURRENCY_TAG, currency)
+                    .register(meterRegistry));
+        }
+    }
+}

--- a/src/main/java/com/payflow/domain/model/wallet/Wallet.java
+++ b/src/main/java/com/payflow/domain/model/wallet/Wallet.java
@@ -59,6 +59,13 @@ public class Wallet {
         this.status = WalletStatus.FROZEN;
     }
 
+    public void unfreeze() {
+        if (status != WalletStatus.FROZEN) {
+            throw new IllegalStateException("Cannot unfreeze wallet with status: " + status);
+        }
+        this.status = WalletStatus.ACTIVE;
+    }
+
     public void validateSufficientBalance(long amountCents) {
         if (amountCents > this.currentBalance) {
             throw new InsufficientBalanceException(this.id, amountCents);

--- a/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
+++ b/src/main/java/com/payflow/infrastructure/persistence/jpa/LedgerEntryJpaRepository.java
@@ -35,18 +35,22 @@ public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntry, UUI
     );
 
     @Query(value = """
-        SELECT
-            t.type                                        AS transactionType,
-            SUM(le.amount)::bigint                        AS totalCents,
-            COUNT(DISTINCT le.transaction_id)::bigint     AS count
-        FROM ledger_entries le
-        JOIN transactions t ON t.id = le.transaction_id
-        WHERE le.wallet_id   = :walletId
-          AND le.created_at >= :from
-          AND le.created_at  < :to
-          AND le.entry_type  = 'DEBIT'
-        GROUP BY t.type
-        ORDER BY totalCents DESC
+
+            SELECT
+              t.type                                        AS transactionType,
+              SUM(le.amount)::bigint                        AS totalCents,
+              COUNT(DISTINCT le.transaction_id)::bigint     AS count
+          FROM ledger_entries le
+          JOIN transactions t ON t.id = le.transaction_id
+          WHERE le.wallet_id   = :walletId
+            AND le.created_at >= :from
+            AND le.created_at  < :to
+            AND (
+                (t.type IN ('WITHDRAW', 'TRANSFER') AND le.entry_type = 'DEBIT')
+                OR (t.type = 'DEPOSIT'             AND le.entry_type = 'CREDIT')
+            )
+          GROUP BY t.type
+          ORDER BY totalCents DESC
         """, nativeQuery = true)
     List<SpendingByCategoryResponse> findSpendingByCategory(
             @Param("walletId") UUID walletId,

--- a/src/test/java/com/payflow/application/command/wallet/UnfreezeWalletCommandHandlerTest.java
+++ b/src/test/java/com/payflow/application/command/wallet/UnfreezeWalletCommandHandlerTest.java
@@ -1,0 +1,92 @@
+package com.payflow.application.command.wallet;
+
+import com.payflow.application.service.WalletService;
+import com.payflow.domain.model.wallet.Wallet;
+import com.payflow.domain.model.wallet.WalletNotFoundException;
+import com.payflow.domain.model.wallet.WalletStatus;
+import com.payflow.domain.repository.WalletRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UnfreezeWalletCommandHandlerTest {
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private WalletService walletService;
+
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    private UnfreezeWalletCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new UnfreezeWalletCommandHandler(
+                walletRepository,
+                walletService,
+                meterRegistry);
+    }
+
+    @Test
+    void shouldUnfreezeFrozenWallet() {
+        UUID userId = UUID.randomUUID();
+        Wallet wallet = Wallet.create(userId, Currency.getInstance("GBP"));
+        wallet.freeze();
+        when(walletRepository.findByIdAndUserId(wallet.getId(), userId)).thenReturn(Optional.of(wallet));
+
+        handler.handle(new UnfreezeWalletCommandHandler.Command(wallet.getId(), userId));
+
+        assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ACTIVE);
+        verify(walletService).save(wallet);
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFound() {
+        UUID walletId = UUID.randomUUID();
+        when(walletRepository.findByIdAndUserId(any(), any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(new UnfreezeWalletCommandHandler.Command(walletId, UUID.randomUUID())))
+                .isInstanceOf(WalletNotFoundException.class);
+
+        verify(walletService, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowWhenUserDoesNotOwnWallet() {
+        UUID ownerId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        Wallet wallet = Wallet.create(ownerId, Currency.getInstance("GBP"));
+        when(walletRepository.findByIdAndUserId(wallet.getId(), otherUserId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(new UnfreezeWalletCommandHandler.Command(wallet.getId(), otherUserId)))
+                .isInstanceOf(WalletNotFoundException.class);
+
+        verify(walletService, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowWhenWalletIsNotFrozen() {
+        UUID userId = UUID.randomUUID();
+        Wallet wallet = Wallet.create(userId, Currency.getInstance("GBP"));
+        when(walletRepository.findByIdAndUserId(wallet.getId(), userId)).thenReturn(Optional.of(wallet));
+
+        assertThatThrownBy(() -> handler.handle(new UnfreezeWalletCommandHandler.Command(wallet.getId(), userId)))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
+++ b/src/test/java/com/payflow/domain/model/wallet/WalletTest.java
@@ -80,4 +80,27 @@ class WalletTest {
         assertThatThrownBy(wallet::freeze)
                 .isInstanceOf(IllegalStateException.class);
     }
+
+    @Test
+    void shouldUnfreezeFrozenWallet() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+        wallet.freeze();
+
+        // When
+        wallet.unfreeze();
+
+        // Then
+        assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ACTIVE);
+    }
+
+    @Test
+    void shouldThrowWhenUnfreezingActiveWallet() {
+        // Given
+        Wallet wallet = Wallet.create(UUID.randomUUID(), Currency.getInstance("GBP"));
+
+        // When / Then
+        assertThatThrownBy(wallet::unfreeze)
+                .isInstanceOf(IllegalStateException.class);
+    }
 }


### PR DESCRIPTION
## What
Adds `POST /api/v1/wallets/{id}/unfreeze` to restore a frozen wallet to active, and fixes `findSpendingByCategory` which was excluding deposits from the spending breakdown.

## Linked Issue
No linked issue.

## Why
The freeze endpoint had no inverse operation, leaving frozen wallets unrecoverable through the API. The spending category query was filtering only on `DEBIT` entries, which silently dropped deposits from the category summary — the fix correctly partitions by transaction type so each type is matched to its expected entry side.

## Changes
- **domain**: `Wallet.unfreeze()` — transitions `FROZEN → ACTIVE`, guards against invalid states
- **application**: `UnfreezeWalletCommandHandler` — SERIALIZABLE transaction, optimistic/pessimistic lock retry, Micrometer counter + latency timer
- **api**: `POST /{id}/unfreeze` endpoint on `WalletController`, returns 204
- **persistence**: `findSpendingByCategory` query now correctly includes `DEPOSIT` (CREDIT) and `WITHDRAW`/`TRANSFER` (DEBIT) entries per transaction type

## Testing
- `WalletTest` — 2 new domain-level cases: happy path unfreeze, guard throws on non-frozen status
- `UnfreezeWalletCommandHandlerTest` — 4 Mockito unit tests: happy path, wallet not found, wrong owner, wallet not frozen
- No integration tests added; Testcontainers would be used if added

## Notes
`LedgerEntryJpaRepository` still uses `nativeQuery = true` (pre-existing); the fix corrects the logic within that constraint without introducing further deviation.